### PR TITLE
Implement Discord bot core with loaders and ping command

### DIFF
--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -1,5 +1,39 @@
+import { EmbedBuilder } from 'discord.js';
+
 export default {
   name: 'ping',
-  description: 'Basic ping command',
-  // TODO: execute(interaction) später implementieren (keine Antwort hier).
+  description: 'Show bot and API latency',
+  async execute(interaction, client) {
+    const start = Date.now();
+    await interaction.deferReply({ ephemeral: false });
+    const roundtrip = Date.now() - start;
+
+    const uptimeMs = client.uptime ?? 0;
+    const uptime = formatDuration(uptimeMs);
+
+    const embed = new EmbedBuilder()
+      .setTitle('The Core System — Status')
+      .setDescription('Operational.')
+      .addFields(
+        { name: 'WebSocket Ping', value: `${client.ws.ping} ms`, inline: true },
+        { name: 'Roundtrip', value: `${roundtrip} ms`, inline: true },
+        { name: 'Uptime', value: uptime, inline: true },
+        { name: 'Server Time', value: new Date().toISOString(), inline: false }
+      )
+      .setColor(0xFFD700)
+      .setTimestamp(new Date())
+      .setFooter({ text: 'The Core System' });
+
+    await interaction.editReply({ embeds: [embed] });
+  },
 };
+
+function formatDuration(ms) {
+  const totalSeconds = Math.floor(ms / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${days}d ${hours}h ${minutes}m ${seconds}s`;
+}
+

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -1,5 +1,34 @@
-// Zweck: Reagiert auf Interaktionen (Slash-Commands).
-// TODO: Prüfen: interaction.isChatInputCommand()
-// TODO: Command anhand interaction.commandName aus Commands-Map holen.
-// TODO: Nur Kommentar zum späteren execute()-Aufruf, keine Logik.
-// TODO: Signatur-Hinweis analog zu ready.js (nur Kommentar).
+export default {
+  name: 'interactionCreate',
+  once: false,
+  async execute(interaction, client) {
+    if (!interaction.isChatInputCommand()) return;
+
+    const command = client.commands?.get(interaction.commandName);
+    if (!command) {
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({ content: 'Unknown command.', ephemeral: true });
+      }
+      return;
+    }
+
+    try {
+      if (typeof command.execute === 'function') {
+        await command.execute(interaction, client);
+      }
+    } catch (error) {
+      console.error(error);
+      const payload = { content: 'An error occurred while executing this command.', ephemeral: true };
+      try {
+        if (interaction.deferred || interaction.replied) {
+          await interaction.followUp(payload);
+        } else {
+          await interaction.reply(payload);
+        }
+      } catch (err) {
+        console.error('Failed to send error reply:', err);
+      }
+    }
+  },
+};
+

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -1,3 +1,8 @@
-// Zweck: Wird einmal ausgelöst, wenn der Client 'ready' ist.
-// TODO: Später ein Log ausgeben ('Bot ready'), jetzt nur Kommentar.
-// TODO: Signatur-Hinweis: export eines Objekts mit { name: 'ready', once: true, execute(client) { ... } } (nur Kommentar, kein Code).
+export default {
+  name: 'ready',
+  once: true,
+  execute(client) {
+    console.log(`[READY] Logged in as ${client.user.tag}`);
+  },
+};
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,11 @@
-// ESM nutzen; kein dotenv. ENV kommen direkt aus process.env (TOKEN, CLIENT_ID, GUILD_ID).
-// TODO: { Client, GatewayIntentBits } aus 'discord.js' importieren.
-// TODO: Client mit minimalen Intents (z. B. GatewayIntentBits.Guilds) erzeugen.
-// TODO: commandLoader & eventLoader importieren und ausführen, um Commands/Events zu registrieren.
-// TODO: client.login(process.env.TOKEN) aufrufen.
+import { Client, GatewayIntentBits } from 'discord.js';
+import commandLoader from './loaders/commandLoader.js';
+import eventLoader from './loaders/eventLoader.js';
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+await commandLoader(client);
+await eventLoader(client);
+
+await client.login(process.env.TOKEN);
+

--- a/src/loaders/commandLoader.js
+++ b/src/loaders/commandLoader.js
@@ -1,5 +1,39 @@
-// Zweck: Alle .js-Dateien aus /src/commands dynamisch sammeln.
-// TODO: Dateiliste ermitteln (nur Kommentar, keine fs-Implementierung).
-// TODO: Je Datei prüfen, ob 'name' und 'description' vorhanden sind.
-// TODO: Eine Commands-Map/Collection vorbereiten (nur Stub, keine echte Datenstruktur).
-// TODO: Diese Map für andere Module verfügbar machen (nur Kommentar, kein Export-Code).
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+export default async function commandLoader(client) {
+  const commandsDir = path.join(process.cwd(), 'src', 'commands');
+  const files = await collectFiles(commandsDir);
+
+  const commands = new Map();
+
+  for (const filePath of files) {
+    try {
+      const command = (await import(filePath)).default;
+      if (typeof command?.name !== 'string' || typeof command?.description !== 'string') {
+        console.warn(`Invalid command structure in ${path.basename(filePath)}`);
+        continue;
+      }
+      commands.set(command.name, command);
+    } catch (err) {
+      console.error(`Failed to load command at ${filePath}:`, err);
+    }
+  }
+
+  client.commands = commands;
+}
+
+async function collectFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const res = path.resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectFiles(res));
+    } else if (entry.isFile() && res.endsWith('.js')) {
+      files.push(res);
+    }
+  }
+  return files;
+}
+

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -1,4 +1,33 @@
-// Zweck: Alle .js-Dateien aus /src/events einlesen und am Client registrieren.
-// TODO: Unterscheidung on/once (z. B. ready = once).
-// TODO: Nur Setup-Beschreibung, keine Implementierung.
-// TODO: späterer Aufruf: eventLoader(client).
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+export default async function eventLoader(client) {
+  const eventsDir = path.join(process.cwd(), 'src', 'events');
+  let files = [];
+  try {
+    files = await readdir(eventsDir);
+  } catch (err) {
+    console.error('Failed to read events directory:', err);
+    return;
+  }
+
+  for (const file of files) {
+    if (!file.endsWith('.js')) continue;
+    const filePath = path.join(eventsDir, file);
+    try {
+      const event = (await import(filePath)).default;
+      if (!event?.name || typeof event.execute !== 'function') {
+        console.warn(`Invalid event structure in ${file}`);
+        continue;
+      }
+      if (event.once) {
+        client.once(event.name, (...args) => event.execute(...args, client));
+      } else {
+        client.on(event.name, (...args) => event.execute(...args, client));
+      }
+    } catch (err) {
+      console.error(`Failed to load event ${file}:`, err);
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add ESM-based client startup that loads commands and events
- implement dynamic command and event loaders
- create ready and interaction handlers with ping status embed
- add script to register guild-specific commands via REST

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node scripts/register-guild-commands.js` *(fails: Expected token to be set for this request, but none was present)*

------
https://chatgpt.com/codex/tasks/task_e_68ab858efa34832dbef87fccdce50286