### PR TITLE
refactor: centralize embed footer and add env guards

### DIFF
--- a/scripts/register-guild-commands.js
+++ b/scripts/register-guild-commands.js
@@ -6,6 +6,11 @@ const applicationId = process.env.CLIENT_ID;
 const guildId = process.env.GUILD_ID;
 const token = process.env.TOKEN;
 
+if (!token || !applicationId || !guildId) {
+  console.error('[ENV] TOKEN/CLIENT_ID/GUILD_ID missing');
+  process.exit(1);
+}
+
 async function readCommands() {
   const commandsDir = path.join(process.cwd(), 'src', 'commands');
   const files = await readdir(commandsDir);
@@ -38,6 +43,7 @@ async function registerGuildCommands() {
     console.log('Guild commands registered successfully.');
   } catch (error) {
     console.error('Error registering guild commands:', error);
+    process.exit(1);
   }
 }
 

--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -1,4 +1,5 @@
 import { EmbedBuilder } from 'discord.js';
+import { FOOTER } from '../util/footer.js';
 
 export default {
   name: 'ping',
@@ -22,7 +23,7 @@ export default {
       )
       .setColor(0xFFD700)
       .setTimestamp(new Date())
-      .setFooter({ text: 'The Core System' });
+      .setFooter(FOOTER);
 
     await interaction.editReply({ embeds: [embed] });
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,11 @@ import { Client, GatewayIntentBits } from 'discord.js';
 import commandLoader from './loaders/commandLoader.js';
 import eventLoader from './loaders/eventLoader.js';
 
+if (!process.env.TOKEN) {
+  console.error('[ENV] TOKEN missing. Set TOKEN in Railway Variables.');
+  process.exit(1);
+}
+
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 await commandLoader(client);

--- a/src/util/footer.js
+++ b/src/util/footer.js
@@ -1,0 +1,2 @@
+// Central embed footer used across commands
+export const FOOTER = { text: 'The Core System' };


### PR DESCRIPTION
## Summary
- centralize embed footer in `FOOTER` constant
- reuse footer in ping command
- add environment guards to bot entry and command registration script

## Testing
- `node scripts/register-guild-commands.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aba92d6d24832d822ad3d1f903c593