### PR TITLE
feat(ping): emoji fields + remove timestamp from footer

### DIFF
--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -13,16 +13,15 @@ export default {
     const uptime = formatDuration(uptimeMs);
 
     const embed = new EmbedBuilder()
-      .setTitle('The Core System — Status')
-      .setDescription('Operational.')
+      .setTitle('🟢 The Core System — Status')
+      .setDescription('✅ Operational.')
       .addFields(
-        { name: 'WebSocket Ping', value: `${client.ws.ping} ms`, inline: true },
-        { name: 'Roundtrip', value: `${roundtrip} ms`, inline: true },
-        { name: 'Uptime', value: uptime, inline: true },
-        { name: 'Server Time', value: new Date().toISOString(), inline: false }
+        { name: '📡 WebSocket Ping', value: `${Math.round(client.ws.ping)} ms`, inline: true },
+        { name: '⏱️ Roundtrip', value: `${roundtrip} ms`, inline: true },
+        { name: '⏳ Uptime', value: uptime, inline: true },
+        { name: '🕒 Server Time', value: new Date().toISOString(), inline: false }
       )
       .setColor(0xFFD700)
-      .setTimestamp(new Date())
       .setFooter(FOOTER);
 
     await interaction.editReply({ embeds: [embed] });


### PR DESCRIPTION
## Summary
- add emojis to ping command embed fields and title
- drop timestamp to keep footer clean

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9f0d543c832d99aa94e8b0a9a43f