### PR TITLE
feat: refine verification flow

### DIFF
--- a/src/events/interactionCreate/handler.js
+++ b/src/events/interactionCreate/handler.js
@@ -9,25 +9,41 @@ export default {
     if (interaction.isButton() && interaction.customId === VERIFY_BUTTON_ID) {
       console.log(`[verify] ${interaction.user.tag} clicked verify`);
       const member = interaction.member ?? await interaction.guild.members.fetch(interaction.user.id);
-      try {
-        if (!member.roles.cache.has(VERIFY_ROLE_ID)) {
-          await member.roles.add(VERIFY_ROLE_ID);
+
+      if (member.roles.cache.has(VERIFY_ROLE_ID)) {
+        const embed = new EmbedBuilder()
+          .setColor(0x00ff00)
+          .setTitle('Verification')
+          .setDescription('ℹ️ You are already verified.')
+          .setFooter(FOOTER);
+        try {
+          await interaction.reply({ embeds: [embed], ephemeral: true });
+        } catch (err) {
+          console.error('[interaction] Failed to send already verified reply:', err);
         }
+        return;
+      }
+
+      try {
+        await member.roles.add(VERIFY_ROLE_ID);
+        const embed = new EmbedBuilder()
+          .setColor(0x00ff00)
+          .setTitle('Verification')
+          .setDescription('✅ You are now verified!')
+          .setFooter(FOOTER);
+        await interaction.reply({ embeds: [embed], ephemeral: true });
       } catch (err) {
         console.error('[verify] Failed to add role:', err);
-      }
-      const embed = new EmbedBuilder()
-        .setColor(0x00ff00)
-        .setDescription('You are now verified!\nDu bist jetzt verifiziert!')
-        .setFooter(FOOTER);
-      try {
-        if (interaction.deferred || interaction.replied) {
-          await interaction.editReply({ embeds: [embed] });
-        } else {
+        const embed = new EmbedBuilder()
+          .setColor(0xFFA500)
+          .setTitle('Verification')
+          .setDescription('⚠️ Verification failed. Please try again or contact staff.')
+          .setFooter(FOOTER);
+        try {
           await interaction.reply({ embeds: [embed], ephemeral: true });
+        } catch (sendErr) {
+          console.error('[interaction] Failed to send verify reply:', sendErr);
         }
-      } catch (err) {
-        console.error('[interaction] Failed to send verify reply:', err);
       }
       return;
     }

--- a/src/features/verify/render.js
+++ b/src/features/verify/render.js
@@ -4,16 +4,24 @@ import { VERIFY_BUTTON_ID, VERIFY_EMOJI } from './config.js';
 
 export function renderVerifyMessage() {
   const embed = new EmbedBuilder()
-    .setColor(0x00ff00)
-    .setTitle('Verification')
-    .setDescription('Click the button to verify.\nKlicke den Button, um dich zu verifizieren.')
+    .setColor(0xFFD700)
+    .setTitle('<a:verify:1355265228862001202> Verify — Verifizierung')
+    .setDescription(`**Verify here**
+*Press the green button to confirm you’re **not a bot** and unlock the server.*
+
+**Hier musst du dich verifizieren**
+*Klicke auf den grünen Button, um zu bestätigen, dass du **kein Bot** bist und den Server freizuschalten.*`)
+    .addFields(
+      { name: 'What you get', value: 'Access to channels and roles like <@&1354909911691038862>.' },
+      { name: 'Was du bekommst', value: 'Zugriff auf Kanäle und Rollen wie <@&1354909911691038862>.' }
+    )
     .setFooter(FOOTER);
 
   const button = new ButtonBuilder()
     .setCustomId(VERIFY_BUTTON_ID)
     .setLabel('Verify')
     .setStyle(ButtonStyle.Success)
-    .setEmoji(VERIFY_EMOJI);
+    .setEmoji({ ...VERIFY_EMOJI, name: 'verify' });
 
   const row = new ActionRowBuilder().addComponents(button);
 


### PR DESCRIPTION
## Summary
- update verify embed with bilingual description, info fields and gold accent
- handle verify button responses for already verified, success, and failure cases

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0b23e598832db509c8476cf0dc6f