### PR TITLE
feat(rules): add rules module

### DIFF
--- a/src/events/interactionCreate/handler.js
+++ b/src/events/interactionCreate/handler.js
@@ -1,17 +1,25 @@
 /*
-### Zweck: Handhabt Verify-Button-Klicks und führt Chat-Input-Commands aus.
+### Zweck: Handhabt Regeln- und Verify-Buttons sowie Chat-Input-Commands.
 */
 import { VERIFY_BUTTON_ID } from '../../modules/verify/config.js';
 import { handleVerifyButton } from '../../modules/verify/interactions.js';
+import { RULES_BUTTON_ID_EN, RULES_BUTTON_ID_DE } from '../../modules/rules/config.js';
+import { handleRulesButtons } from '../../modules/rules/interactions.js';
 import { logger } from '../../util/logger.js';
 
 export default {
   name: 'interactionCreate',
   once: false,
   async execute(interaction, client) {
-    if (interaction.isButton() && interaction.customId === VERIFY_BUTTON_ID) {
-      await handleVerifyButton(interaction, client);
-      return;
+    if (interaction.isButton()) {
+      if (interaction.customId === RULES_BUTTON_ID_EN || interaction.customId === RULES_BUTTON_ID_DE) {
+        await handleRulesButtons(interaction, client);
+        return;
+      }
+      if (interaction.customId === VERIFY_BUTTON_ID) {
+        await handleVerifyButton(interaction, client);
+        return;
+      }
     }
 
     if (!interaction.isChatInputCommand()) return;

--- a/src/events/ready/handler.js
+++ b/src/events/ready/handler.js
@@ -1,7 +1,8 @@
 /*
-### Zweck: READY-Event – loggt Anmeldung und stößt die Verify-Nachricht-Prüfung an.
+### Zweck: READY-Event – loggt Anmeldung und stößt die Verify- und Regelnachrichten-Prüfung an.
 */
 import ensureVerifyMessage from '../../modules/verify/ensure.js';
+import { ensureRulesMessage } from '../../modules/rules/ensure.js';
 import { logger } from '../../util/logger.js';
 
 export default {
@@ -14,6 +15,10 @@ export default {
     } catch (err) {
       logger.error('[verifizierung] Fehler beim Sicherstellen der Nachricht:', err);
     }
+    try {
+      await ensureRulesMessage(client);
+    } catch (err) {
+      logger.error('[regeln] Fehler beim Sicherstellen der Nachricht:', err);
+    }
   },
 };
-

--- a/src/modules/rules/config.js
+++ b/src/modules/rules/config.js
@@ -1,0 +1,9 @@
+/*
+### Zweck: Hält nur IDs/Konstanten für das Rules-Feature (Channel, Nachricht, Buttons, Default-Sprache, Reset-Zeit).
+*/
+export const RULES_CHANNEL_ID = '1354914857538945205';
+export const RULES_MESSAGE_ID = '';
+export const RULES_BUTTON_ID_EN = 'rules_lang_en';
+export const RULES_BUTTON_ID_DE = 'rules_lang_de';
+export const RULES_DEFAULT_LANG = 'en';
+export const RULES_RESET_MS = 300000;

--- a/src/modules/rules/embed.js
+++ b/src/modules/rules/embed.js
@@ -1,0 +1,58 @@
+/*
+### Zweck: Baut die Rules-Embed und die Sprachwahl-Buttons.
+*/
+import { EmbedBuilder, ButtonBuilder, ActionRowBuilder, ButtonStyle } from 'discord.js';
+import { FOOTER } from '../../util/footer.js';
+import { RULES_BUTTON_ID_EN, RULES_BUTTON_ID_DE } from './config.js';
+
+export function buildRulesEmbedAndComponents(lang) {
+  const isDe = lang === 'de';
+  const title = isDe ? '📜 Server-Regeln — Bitte lesen' : '📜 Server Rules — Please Read';
+  const description = isDe
+    ? `**Willkommen!** Bitte halte dich an diese Regeln – für Sicherheit und Spaß.
+
+1️⃣ **Sei respektvoll** — keine Belästigung, Hassrede oder Beleidigungen.  
+2️⃣ **Bleib beim Thema** — nutze die Kanäle zweckgemäß.  
+3️⃣ **Kein Spam oder Eigenwerbung** — keine unerbetene Werbung, Massen-Pings oder Link-Fluten.  
+4️⃣ **Sicherer Inhalt** — kein NSFW, nichts Illegales, keine Malware oder Exploits.  
+5️⃣ **Privatsphäre zuerst** — kein Doxxing, keine Weitergabe persönlicher Daten.  
+6️⃣ **Team-Entscheidungen** — Folge den Mods; Einsprüche sachlich.  
+7️⃣ **Sprache** — halte Nachrichten lesbar; Englisch, außer ein Kanal sagt etwas anderes.  
+8️⃣ **Sicherheit** — melde Verdächtiges; keine Imitationen.
+
+**Durchsetzung:** Verwarnungen, Mutes, Kicks, Bans — nach Ermessen des Teams.`
+    : `**Welcome!** Please follow these rules to keep things safe and fun.
+
+1️⃣ **Be respectful** — no harassment, hate speech, or slurs.  
+2️⃣ **Stay on topic** — use channels for their purpose.  
+3️⃣ **No spam or self-promo** — no unsolicited ads, mass pings, or link dumps.  
+4️⃣ **Safe content** — no NSFW, illegal content, malware, or exploits.  
+5️⃣ **Privacy first** — no doxxing or sharing personal data.  
+6️⃣ **Staff decisions** — follow moderator instructions; appeal politely.  
+7️⃣ **Language** — keep messages readable; use English unless a channel says otherwise.  
+8️⃣ **Security** — report suspicious behavior; no impersonation.
+
+**Enforcement:** Warnings, mutes, kicks, bans — at staff discretion.`;
+
+  const embed = new EmbedBuilder()
+    .setColor(0xFFD700)
+    .setTitle(title)
+    .setDescription(description)
+    .setFooter(FOOTER);
+
+  const enButton = new ButtonBuilder()
+    .setCustomId(RULES_BUTTON_ID_EN)
+    .setLabel('English')
+    .setStyle(ButtonStyle.Primary)
+    .setEmoji('🇺🇸');
+
+  const deButton = new ButtonBuilder()
+    .setCustomId(RULES_BUTTON_ID_DE)
+    .setLabel('Deutsch')
+    .setStyle(ButtonStyle.Secondary)
+    .setEmoji('🇩🇪');
+
+  const row = new ActionRowBuilder().addComponents(enButton, deButton);
+
+  return { embeds: [embed], components: [row] };
+}

--- a/src/modules/rules/ensure.js
+++ b/src/modules/rules/ensure.js
@@ -1,0 +1,61 @@
+/*
+### Zweck: Stellt sicher, dass genau eine Rules-Nachricht existiert (aktualisieren oder neu senden).
+*/
+import { RULES_CHANNEL_ID, RULES_MESSAGE_ID, RULES_BUTTON_ID_EN, RULES_BUTTON_ID_DE, RULES_DEFAULT_LANG } from './config.js';
+import { buildRulesEmbedAndComponents } from './embed.js';
+import { logger } from '../../util/logger.js';
+
+export async function ensureRulesMessage(client) {
+  let channel;
+  try {
+    channel = await client.channels.fetch(RULES_CHANNEL_ID);
+  } catch (err) {
+    logger.error('[regeln] Fehler beim Sicherstellen der Nachricht:', err);
+    return;
+  }
+  if (!channel || !channel.isTextBased()) {
+    logger.warn('[regeln] Kanal nicht gefunden oder nicht textbasiert: ' + RULES_CHANNEL_ID);
+    return;
+  }
+
+  const payload = buildRulesEmbedAndComponents(RULES_DEFAULT_LANG);
+  let message = null;
+
+  if (RULES_MESSAGE_ID) {
+    try {
+      message = await channel.messages.fetch(RULES_MESSAGE_ID);
+    } catch {
+      // ignore
+    }
+  }
+
+  if (!message) {
+    try {
+      const messages = await channel.messages.fetch({ limit: 10 });
+      message = messages.find((m) =>
+        m.author?.id === client.user?.id &&
+        m.components.some((row) =>
+          row.components.some((c) => c.customId === RULES_BUTTON_ID_EN || c.customId === RULES_BUTTON_ID_DE)
+        )
+      );
+    } catch (err) {
+      logger.error('[regeln] Fehler beim Sicherstellen der Nachricht:', err);
+    }
+  }
+
+  if (message) {
+    try {
+      await message.edit(payload);
+      logger.info('[regeln] Nachricht aktualisiert');
+    } catch (err) {
+      logger.error('[regeln] Fehler beim Sicherstellen der Nachricht:', err);
+    }
+  } else {
+    try {
+      await channel.send(payload);
+      logger.info('[regeln] Nachricht erstellt');
+    } catch (err) {
+      logger.error('[regeln] Fehler beim Sicherstellen der Nachricht:', err);
+    }
+  }
+}

--- a/src/modules/rules/interactions.js
+++ b/src/modules/rules/interactions.js
@@ -1,0 +1,35 @@
+/*
+### Zweck: Handhabt die Sprachbuttons und setzt per Timeout auf Englisch zurück.
+*/
+import { RULES_BUTTON_ID_EN, RULES_BUTTON_ID_DE, RULES_DEFAULT_LANG, RULES_RESET_MS } from './config.js';
+import { buildRulesEmbedAndComponents } from './embed.js';
+import { logger } from '../../util/logger.js';
+
+const timeouts = new Map();
+
+export async function handleRulesButtons(interaction, client) {
+  const lang = interaction.customId === RULES_BUTTON_ID_DE ? 'de' : 'en';
+  const message = interaction.message;
+  try {
+    await interaction.update(buildRulesEmbedAndComponents(lang));
+    logger.info(`[regeln] Sprache → ${lang.toUpperCase()}`);
+  } catch (err) {
+    logger.error('[regeln] Fehler beim Umschalten der Sprache:', err);
+    return;
+  }
+
+  const messageId = message.id;
+  if (timeouts.has(messageId)) {
+    clearTimeout(timeouts.get(messageId));
+  }
+  const timeout = setTimeout(async () => {
+    try {
+      await message.edit(buildRulesEmbedAndComponents(RULES_DEFAULT_LANG));
+      logger.info('[regeln] Sprache → EN (Timeout)');
+    } catch (err) {
+      logger.error('[regeln] Fehler beim Zurücksetzen der Sprache:', err);
+    }
+    timeouts.delete(messageId);
+  }, RULES_RESET_MS);
+  timeouts.set(messageId, timeout);
+}


### PR DESCRIPTION
## Summary
- add rules module with multilingual embeds and language toggle buttons
- ensure rules message exists on startup and auto-reset language after inactivity
- wire up rules button handling and ready event integration

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dabe5180832dafb134e3e84861ae