### PR TITLE
feat(rules): add multilingual embed

### DIFF
--- a/src/modules/rules/embed.js
+++ b/src/modules/rules/embed.js
@@ -1,56 +1,142 @@
 /*
 ### Zweck: Baut die Rules-Embed und die Sprachwahl-Buttons.
 */
-import { EmbedBuilder, ButtonBuilder, ActionRowBuilder, ButtonStyle } from 'discord.js';
-import { FOOTER } from '../../util/footer.js';
-import { RULES_BUTTON_ID_EN, RULES_BUTTON_ID_DE } from './config.js';
+import {
+  EmbedBuilder,
+  ButtonBuilder,
+  ActionRowBuilder,
+  ButtonStyle,
+} from "discord.js";
+import { FOOTER } from "../../util/footer.js";
+import { RULES_BUTTON_ID_EN, RULES_BUTTON_ID_DE } from "./config.js";
 
-export function buildRulesEmbedAndComponents(lang) {
-  const isDe = lang === 'de';
-  const title = isDe ? '📜 Server-Regeln — Bitte lesen' : '📜 Server Rules — Please Read';
-  const description = isDe
-    ? `**Willkommen!** Bitte halte dich an diese Regeln – für Sicherheit und Spaß.
+const FIELDS_EN = [
+  {
+    name: "🤝 __**Respect & Safety**__",
+    value:
+      "> **Be respectful** — no harassment, hate speech, or slurs. Keep it welcoming.",
+    inline: false,
+  },
+  {
+    name: "🗂️ __**Stay on Topic**__",
+    value:
+      "> Use channels for their purpose; off-topic goes to the right place.",
+    inline: false,
+  },
+  {
+    name: "🚫 __**No Spam / Self-Promo**__",
+    value: "> **No spam**, unsolicited ads, mass pings, or link dumps.",
+    inline: false,
+  },
+  {
+    name: "⚠️ __**Safe Content**__",
+    value: "> **No NSFW**, illegal content, malware or exploits.",
+    inline: false,
+  },
+  {
+    name: "🔐 __**Privacy First**__",
+    value: "> **No doxxing** or sharing personal data of yourself or others.",
+    inline: false,
+  },
+  {
+    name: "🛠️ __**Staff Decisions**__",
+    value: "> Follow moderator instructions; appeal **politely** if needed.",
+    inline: false,
+  },
+  {
+    name: "🌐 __**Language**__",
+    value:
+      "> Keep messages readable; **English** unless a channel states otherwise.",
+    inline: false,
+  },
+  {
+    name: "🛡️ __**Security**__",
+    value:
+      "> Report suspicious behavior; **no impersonation** of staff or users.",
+    inline: false,
+  },
+  {
+    name: "📏 __**Enforcement**__",
+    value: "> Warnings, mutes, kicks, bans — at staff discretion.",
+    inline: false,
+  },
+];
 
-1️⃣ **Sei respektvoll** — keine Belästigung, Hassrede oder Beleidigungen.  
-2️⃣ **Bleib beim Thema** — nutze die Kanäle zweckgemäß.  
-3️⃣ **Kein Spam oder Eigenwerbung** — keine unerbetene Werbung, Massen-Pings oder Link-Fluten.  
-4️⃣ **Sicherer Inhalt** — kein NSFW, nichts Illegales, keine Malware oder Exploits.  
-5️⃣ **Privatsphäre zuerst** — kein Doxxing, keine Weitergabe persönlicher Daten.  
-6️⃣ **Team-Entscheidungen** — Folge den Mods; Einsprüche sachlich.  
-7️⃣ **Sprache** — halte Nachrichten lesbar; Englisch, außer ein Kanal sagt etwas anderes.  
-8️⃣ **Sicherheit** — melde Verdächtiges; keine Imitationen.
+const FIELDS_DE = [
+  {
+    name: "🤝 __**Respekt & Sicherheit**__",
+    value:
+      "> **Sei respektvoll** — keine Belästigung, Hassrede oder Beleidigungen.",
+    inline: false,
+  },
+  {
+    name: "🗂️ __**Beim Thema bleiben**__",
+    value:
+      "> Nutze Kanäle zweckgemäß; Off-Topic gehört in den passenden Bereich.",
+    inline: false,
+  },
+  {
+    name: "🚫 __**Kein Spam / Eigenwerbung**__",
+    value:
+      "> **Kein Spam**, keine unerbetene Werbung, Massen-Pings oder Link-Fluten.",
+    inline: false,
+  },
+  {
+    name: "⚠️ __**Sicherer Inhalt**__",
+    value: "> **Kein NSFW**, nichts Illegales, keine Malware oder Exploits.",
+    inline: false,
+  },
+  {
+    name: "🔐 __**Privatsphäre zuerst**__",
+    value: "> **Kein Doxxing** oder Weitergabe persönlicher Daten.",
+    inline: false,
+  },
+  {
+    name: "🛠️ __**Team-Entscheidungen**__",
+    value: "> Folge den Anweisungen der Moderation; Einsprüche **sachlich**.",
+    inline: false,
+  },
+  {
+    name: "🌐 __**Sprache**__",
+    value:
+      "> Halte Nachrichten lesbar; **Englisch**, außer ein Kanal sagt anderes.",
+    inline: false,
+  },
+  {
+    name: "🛡️ __**Sicherheit**__",
+    value:
+      "> Melde Verdächtiges; **keine Imitationen** von Team oder Nutzer*innen.",
+    inline: false,
+  },
+  {
+    name: "📏 __**Durchsetzung**__",
+    value: "> Verwarnungen, Mutes, Kicks, Bans — nach Ermessen des Teams.",
+    inline: false,
+  },
+];
 
-**Durchsetzung:** Verwarnungen, Mutes, Kicks, Bans — nach Ermessen des Teams.`
-    : `**Welcome!** Please follow these rules to keep things safe and fun.
-
-1️⃣ **Be respectful** — no harassment, hate speech, or slurs.  
-2️⃣ **Stay on topic** — use channels for their purpose.  
-3️⃣ **No spam or self-promo** — no unsolicited ads, mass pings, or link dumps.  
-4️⃣ **Safe content** — no NSFW, illegal content, malware, or exploits.  
-5️⃣ **Privacy first** — no doxxing or sharing personal data.  
-6️⃣ **Staff decisions** — follow moderator instructions; appeal politely.  
-7️⃣ **Language** — keep messages readable; use English unless a channel says otherwise.  
-8️⃣ **Security** — report suspicious behavior; no impersonation.
-
-**Enforcement:** Warnings, mutes, kicks, bans — at staff discretion.`;
+export function buildRulesEmbedAndComponents(lang = "en") {
+  const isDe = lang === "de";
+  const fields = isDe ? FIELDS_DE : FIELDS_EN;
+  const title = isDe ? "📜 Regeln — Bitte lesen" : "📜 Rules — Please Read";
 
   const embed = new EmbedBuilder()
-    .setColor(0xFFD700)
+    .setColor(0xffd700)
     .setTitle(title)
-    .setDescription(description)
+    .setFields(fields)
     .setFooter(FOOTER);
 
   const enButton = new ButtonBuilder()
     .setCustomId(RULES_BUTTON_ID_EN)
-    .setLabel('English')
+    .setLabel("English")
     .setStyle(ButtonStyle.Primary)
-    .setEmoji('🇺🇸');
+    .setEmoji("🇺🇸");
 
   const deButton = new ButtonBuilder()
     .setCustomId(RULES_BUTTON_ID_DE)
-    .setLabel('Deutsch')
+    .setLabel("Deutsch")
     .setStyle(ButtonStyle.Secondary)
-    .setEmoji('🇩🇪');
+    .setEmoji("🇩🇪");
 
   const row = new ActionRowBuilder().addComponents(enButton, deButton);
 


### PR DESCRIPTION
## Summary
- format rules as fields with bold titles and quoted descriptions
- provide English/German toggle buttons on a gold embed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e2b7f774832dbdb3160f0a48eb57