### PR TITLE
fix teamlist role mentions

### DIFF
--- a/src/modules/teamlist/embed.js
+++ b/src/modules/teamlist/embed.js
@@ -40,10 +40,11 @@ export async function buildTeamEmbedAndComponents(lang = 'en', guild) {
 
   for (const role of TEAM_ROLES) {
     const desc = isDe ? role.descDe : role.descEn;
+    const label = isDe ? role.labelDe : role.labelEn;
     const mentions = await getRoleMemberMentions(guild, role.id);
     if (mentions.length === 0) continue;
-    const value = `\`${desc}\`\n${mentions.join('\n')}`;
-    embed.addFields({ name: `<@&${role.id}>`, value, inline: false });
+    const value = `<@&${role.id}>\n\`${desc}\`\n${mentions.join('\n')}`;
+    embed.addFields({ name: label, value, inline: false });
   }
 
   const enButton = new ButtonBuilder()

--- a/src/modules/teamlist/ensure.js
+++ b/src/modules/teamlist/ensure.js
@@ -1,7 +1,7 @@
 /*
 ### Zweck: Stellt sicher, dass genau eine Teamlisten-Nachricht existiert.
 */
-import { TEAM_CHANNEL_ID, TEAM_MESSAGE_ID, TEAM_BUTTON_ID_EN, TEAM_BUTTON_ID_DE } from './config.js';
+import { TEAM_CHANNEL_ID, TEAM_MESSAGE_ID, TEAM_BUTTON_ID_EN, TEAM_BUTTON_ID_DE, TEAM_ROLES } from './config.js';
 import { buildTeamEmbedAndComponents } from './embed.js';
 import { logger } from '../../util/logger.js';
 
@@ -50,16 +50,18 @@ export async function ensureTeamMessage(client) {
     }
   }
 
+  const allowedMentions = { parse: [], roles: TEAM_ROLES.map(r => r.id), users: [] };
+
   if (message) {
     try {
-      await message.edit(payload);
+      await message.edit({ ...payload, allowedMentions });
       logger.info('[team] Nachricht aktualisiert');
     } catch (err) {
       logger.error('[team] Fehler beim Sicherstellen der Nachricht:', err);
     }
   } else {
     try {
-      await channel.send(payload);
+      await channel.send({ ...payload, allowedMentions });
       logger.info('[team] Nachricht erstellt');
     } catch (err) {
       logger.error('[team] Fehler beim Sicherstellen der Nachricht:', err);

--- a/src/modules/teamlist/interactions.js
+++ b/src/modules/teamlist/interactions.js
@@ -1,16 +1,17 @@
 /*
 ### Zweck: Handhabt Sprachwechsel-Buttons der Teamliste und Timeout-Rücksetzung.
 */
-import { TEAM_BUTTON_ID_EN, TEAM_BUTTON_ID_DE, TEAM_RESET_MS } from './config.js';
+import { TEAM_BUTTON_ID_EN, TEAM_BUTTON_ID_DE, TEAM_RESET_MS, TEAM_ROLES } from './config.js';
 import { buildTeamEmbedAndComponents } from './embed.js';
 import { logger } from '../../util/logger.js';
 
 const timeouts = new Map();
 
 export async function handleTeamButtons(interaction, client) {
+  const allowedMentions = { parse: [], roles: TEAM_ROLES.map(r => r.id), users: [] };
   const lang = interaction.customId === TEAM_BUTTON_ID_DE ? 'de' : 'en';
   try {
-    await interaction.update(await buildTeamEmbedAndComponents(lang, interaction.guild));
+    await interaction.update({ ...(await buildTeamEmbedAndComponents(lang, interaction.guild)), allowedMentions });
     logger.info(`[team] Sprache → ${lang.toUpperCase()}`);
   } catch (err) {
     logger.error('[team] Fehler beim Umschalten der Sprache:', err);
@@ -24,7 +25,7 @@ export async function handleTeamButtons(interaction, client) {
   const timeout = setTimeout(async () => {
     try {
       const payload = await buildTeamEmbedAndComponents('en', interaction.guild);
-      await interaction.message.edit(payload);
+      await interaction.message.edit({ ...payload, allowedMentions });
       logger.info('[team] Sprache → EN (Timeout)');
     } catch (err) {
       logger.error('[team] Fehler beim Zurücksetzen der Sprache:', err);


### PR DESCRIPTION
## Summary
- render teamlist fields with plain role labels, mention, description, and members
- restrict allowed mentions to specific roles when sending or editing teamlist message

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cb63da94832da6446349e602520d