### PR TITLE
feat: add verify language switching

### DIFF
--- a/src/events/interactionCreate/handler.js
+++ b/src/events/interactionCreate/handler.js
@@ -1,8 +1,8 @@
 /*
 ### Zweck: Handhabt Regeln-, Verify- und Teamlisten-Buttons sowie Chat-Input-Commands.
 */
-import { VERIFY_BUTTON_ID } from '../../modules/verify/config.js';
-import { handleVerifyButton } from '../../modules/verify/interactions.js';
+import { VERIFY_BUTTON_ID, VERIFY_LANG_EN_ID, VERIFY_LANG_DE_ID } from '../../modules/verify/config.js';
+import { handleVerifyInteractions } from '../../modules/verify/interactions.js';
 import { RULES_BUTTON_ID_EN, RULES_BUTTON_ID_DE } from '../../modules/rules/config.js';
 import { handleRulesButtons } from '../../modules/rules/interactions.js';
 import { TEAM_BUTTON_ID_EN, TEAM_BUTTON_ID_DE } from '../../modules/teamlist/config.js';
@@ -14,16 +14,20 @@ export default {
   once: false,
   async execute(interaction, client) {
     if (interaction.isButton()) {
+      if (
+        interaction.customId === VERIFY_BUTTON_ID ||
+        interaction.customId === VERIFY_LANG_EN_ID ||
+        interaction.customId === VERIFY_LANG_DE_ID
+      ) {
+        await handleVerifyInteractions(interaction, client);
+        return;
+      }
       if (interaction.customId === TEAM_BUTTON_ID_EN || interaction.customId === TEAM_BUTTON_ID_DE) {
         await handleTeamButtons(interaction, client);
         return;
       }
       if (interaction.customId === RULES_BUTTON_ID_EN || interaction.customId === RULES_BUTTON_ID_DE) {
         await handleRulesButtons(interaction, client);
-        return;
-      }
-      if (interaction.customId === VERIFY_BUTTON_ID) {
-        await handleVerifyButton(interaction, client);
         return;
       }
     }

--- a/src/modules/verify/config.js
+++ b/src/modules/verify/config.js
@@ -1,8 +1,10 @@
 /*
-### Zweck: Hält nur IDs/Konstanten für das Verify-Feature (Channel, Rolle, Button, Emoji, MessageID).
+### Zweck: Hält IDs/Konstanten für das Verify-Feature (Channel, Rolle, Buttons, Sprache).
 */
 export const VERIFY_CHANNEL_ID = '1354914940611330239';
 export const VERIFY_ROLE_ID = '1354909911691038862';
-export const VERIFY_MESSAGE_ID = '1409745967883747491';
-export const VERIFY_BUTTON_ID = 'verify_click';
-export const VERIFY_EMOJI = { id: '1355265228862001202', animated: true };
+export const VERIFY_BUTTON_ID = 'verify_action';
+export const VERIFY_LANG_EN_ID = 'verify_lang_en';
+export const VERIFY_LANG_DE_ID = 'verify_lang_de';
+export const VERIFY_DEFAULT_LANG = 'en';
+export const VERIFY_RESET_MS = 300000;

--- a/src/modules/verify/embed.js
+++ b/src/modules/verify/embed.js
@@ -1,32 +1,72 @@
 /*
-### Zweck: Baut die zweisprachige Verify-Embed und den grünen Verify-Button.
+### Zweck: Baut die Verify-Embed samt Sprach- und Verify-Buttons.
 */
 import { EmbedBuilder, ButtonBuilder, ActionRowBuilder, ButtonStyle } from 'discord.js';
 import { FOOTER } from '../../util/footer.js';
-import { VERIFY_BUTTON_ID, VERIFY_EMOJI } from './config.js';
+import {
+  VERIFY_BUTTON_ID,
+  VERIFY_LANG_EN_ID,
+  VERIFY_LANG_DE_ID,
+  VERIFY_DEFAULT_LANG,
+  VERIFY_ROLE_ID,
+} from './config.js';
 
-export function buildVerifyEmbedAndComponents() {
+export function buildVerifyEmbedAndComponents(lang = VERIFY_DEFAULT_LANG) {
+  const isDe = lang === 'de';
+  const title = isDe
+    ? '✅ Verifizierung — Zugriff auf den Server'
+    : '✅ Verify — Access the Server';
+  const description = isDe
+    ? '🛡️ *Offizielle Verifizierung von **The Core Team** — bitte bestätige, dass du kein Bot bist.*'
+    : '🛡️ *Official verification by **The Core Team** — please confirm you’re not a bot.*';
+  const fields = isDe
+    ? [
+        {
+          name: '🎯 __**Was passiert**__',
+          value: `> Du schaltest Kanäle & Rollen frei, z. B. <@&${VERIFY_ROLE_ID}>.`,
+        },
+        {
+          name: 'ℹ️ __**So geht’s**__',
+          value: '> Klicke **Verify**. Geht sofort und ist sicher.',
+        },
+      ]
+    : [
+        {
+          name: '🎯 __**What happens**__',
+          value: `> You unlock channels & roles like <@&${VERIFY_ROLE_ID}>.`,
+        },
+        {
+          name: 'ℹ️ __**How to**__',
+          value: '> Press **Verify**. It’s instant and safe.',
+        },
+      ];
+
   const embed = new EmbedBuilder()
     .setColor(0xFFD700)
-    .setTitle('<a:verify:1355265228862001202> Verify — Verifizierung')
-    .setDescription(`**Verify here**
-*Press the green button to confirm you’re **not a bot** and unlock the server.*
-
-**Hier musst du dich verifizieren**
-*Klicke auf den grünen Button, um zu bestätigen, dass du **kein Bot** bist und den Server freizuschalten.*`)
-    .addFields(
-      { name: 'What you get', value: 'Access to channels and roles like <@&1354909911691038862>.' },
-      { name: 'Was du bekommst', value: 'Zugriff auf Kanäle und Rollen wie <@&1354909911691038862>.' }
-    )
+    .setTitle(title)
+    .setDescription(description)
+    .addFields(fields)
     .setFooter(FOOTER);
 
-  const button = new ButtonBuilder()
+  const verifyButton = new ButtonBuilder()
     .setCustomId(VERIFY_BUTTON_ID)
     .setLabel('Verify')
     .setStyle(ButtonStyle.Success)
-    .setEmoji({ ...VERIFY_EMOJI, name: 'verify' });
+    .setEmoji({ id: '1355265228862001202', name: 'verify', animated: true });
 
-  const row = new ActionRowBuilder().addComponents(button);
+  const row1 = new ActionRowBuilder().addComponents(verifyButton);
 
-  return { embeds: [embed], components: [row] };
+  const langEnButton = new ButtonBuilder()
+    .setCustomId(VERIFY_LANG_EN_ID)
+    .setLabel('🇺🇸 English')
+    .setStyle(ButtonStyle.Primary);
+
+  const langDeButton = new ButtonBuilder()
+    .setCustomId(VERIFY_LANG_DE_ID)
+    .setLabel('🇩🇪 Deutsch')
+    .setStyle(ButtonStyle.Secondary);
+
+  const row2 = new ActionRowBuilder().addComponents(langEnButton, langDeButton);
+
+  return { embeds: [embed], components: [row1, row2] };
 }

--- a/src/modules/verify/ensure.js
+++ b/src/modules/verify/ensure.js
@@ -1,7 +1,7 @@
 /*
 ### Zweck: Stellt sicher, dass genau eine Verify-Nachricht existiert (aktualisieren oder neu senden).
 */
-import { VERIFY_CHANNEL_ID, VERIFY_MESSAGE_ID, VERIFY_BUTTON_ID } from './config.js';
+import { VERIFY_CHANNEL_ID, VERIFY_BUTTON_ID, VERIFY_DEFAULT_LANG } from './config.js';
 import { buildVerifyEmbedAndComponents } from './embed.js';
 import { logger } from '../../util/logger.js';
 
@@ -10,51 +10,41 @@ export default async function ensureVerifyMessage(client) {
   try {
     channel = await client.channels.fetch(VERIFY_CHANNEL_ID);
   } catch (err) {
-    logger.error('[verifizierung] Fehler beim Sicherstellen der Nachricht:', err);
+    logger.error('[verify] Fehler beim Sicherstellen der Nachricht:', err);
     return;
   }
   if (!channel || !channel.isTextBased()) {
-    logger.warn('[verifizierung] Kanal nicht gefunden oder nicht textbasiert: ' + VERIFY_CHANNEL_ID);
+    logger.warn('[verify] Kanal nicht gefunden oder nicht textbasiert: ' + VERIFY_CHANNEL_ID);
     return;
   }
 
-  const payload = buildVerifyEmbedAndComponents();
+  const payload = buildVerifyEmbedAndComponents(VERIFY_DEFAULT_LANG);
   let message = null;
 
-    if (VERIFY_MESSAGE_ID) {
-      try {
-        message = await channel.messages.fetch(VERIFY_MESSAGE_ID);
-      } catch {
-        // ignore
-      }
-    }
+  try {
+    const messages = await channel.messages.fetch({ limit: 10 });
+    message = messages.find((m) =>
+      m.components.some((row) =>
+        row.components.some((c) => c.customId === VERIFY_BUTTON_ID)
+      )
+    );
+  } catch (err) {
+    logger.error('[verify] Fehler beim Sicherstellen der Nachricht:', err);
+  }
 
-    if (!message) {
-      try {
-        const messages = await channel.messages.fetch({ limit: 10 });
-        message = messages.find((m) =>
-          m.components.some((row) =>
-            row.components.some((c) => c.customId === VERIFY_BUTTON_ID)
-          )
-        );
-      } catch (err) {
-        logger.error('[verifizierung] Fehler beim Sicherstellen der Nachricht:', err);
-      }
+  if (message) {
+    try {
+      await message.edit(payload);
+      logger.info('[verify] Nachricht aktualisiert');
+    } catch (err) {
+      logger.error('[verify] Fehler beim Sicherstellen der Nachricht:', err);
     }
-
-    if (message) {
-      try {
-        await message.edit(payload);
-        logger.info('[verifizierung] Nachricht aktualisiert');
-      } catch (err) {
-        logger.error('[verifizierung] Fehler beim Sicherstellen der Nachricht:', err);
-      }
-    } else {
-      try {
-        await channel.send(payload);
-        logger.info('[verifizierung] Nachricht erstellt');
-      } catch (err) {
-        logger.error('[verifizierung] Fehler beim Sicherstellen der Nachricht:', err);
-      }
+  } else {
+    try {
+      await channel.send(payload);
+      logger.info('[verify] Nachricht erstellt');
+    } catch (err) {
+      logger.error('[verify] Fehler beim Sicherstellen der Nachricht:', err);
     }
+  }
 }

--- a/src/modules/verify/interactions.js
+++ b/src/modules/verify/interactions.js
@@ -1,49 +1,98 @@
 /*
-### Zweck: Vergibt bei Verify-Klick die Rolle und sendet ephemere EN-Bestätigungen (success/already/error).
+### Zweck: Handhabt Verify- und Sprachwechsel-Buttons.
 */
 import { EmbedBuilder } from 'discord.js';
-import { VERIFY_ROLE_ID } from './config.js';
+import {
+  VERIFY_ROLE_ID,
+  VERIFY_BUTTON_ID,
+  VERIFY_LANG_EN_ID,
+  VERIFY_LANG_DE_ID,
+  VERIFY_RESET_MS,
+} from './config.js';
+import { buildVerifyEmbedAndComponents } from './embed.js';
 import { FOOTER } from '../../util/footer.js';
 import { logger } from '../../util/logger.js';
 
-export async function handleVerifyButton(interaction, client) {
-  const member = interaction.member ?? await interaction.guild.members.fetch(interaction.user.id).catch(() => null);
-  if (!member) {
-    const embed = new EmbedBuilder()
-      .setColor(0xFFA500)
-      .setTitle('Verification')
-      .setDescription('⚠️ Verification failed. Please try again or contact staff.')
-      .setFooter(FOOTER);
-    try { await interaction.reply({ embeds: [embed], ephemeral: true }); } catch {}
-    logger.warn('[verifizierung] Mitglied konnte nicht ermittelt werden');
+const verifyLangTimers = new Map();
+
+export async function handleVerifyInteractions(interaction, client) {
+  if (interaction.customId === VERIFY_BUTTON_ID) {
+    const member =
+      interaction.member ??
+      (await interaction.guild.members.fetch(interaction.user.id).catch(() => null));
+    if (!member) {
+      const embed = new EmbedBuilder()
+        .setColor(0xFFA500)
+        .setTitle('Verification')
+        .setDescription('⚠️ Verification failed. Please try again or contact staff.')
+        .setFooter(FOOTER);
+      try {
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+      } catch {}
+      logger.warn('[verify] Mitglied nicht gefunden');
+      return;
+    }
+
+    if (member.roles.cache.has(VERIFY_ROLE_ID)) {
+      const embed = new EmbedBuilder()
+        .setColor(0x00ff00)
+        .setTitle('Verification')
+        .setDescription('ℹ️ You are already verified.')
+        .setFooter(FOOTER);
+      try {
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+      } catch {}
+      return;
+    }
+
+    try {
+      await member.roles.add(VERIFY_ROLE_ID);
+      const embed = new EmbedBuilder()
+        .setColor(0x00ff00)
+        .setTitle('Verification')
+        .setDescription('✅ You are now verified!')
+        .setFooter(FOOTER);
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+    } catch (err) {
+      logger.warn('[verify] Rolle konnte nicht vergeben', err);
+      const embed = new EmbedBuilder()
+        .setColor(0xFFA500)
+        .setTitle('Verification')
+        .setDescription('⚠️ Verification failed. Please try again or contact staff.')
+        .setFooter(FOOTER);
+      try {
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+      } catch {}
+    }
     return;
   }
 
-  if (member.roles.cache.has(VERIFY_ROLE_ID)) {
-    const embed = new EmbedBuilder()
-      .setColor(0x00ff00)
-      .setTitle('Verification')
-      .setDescription('ℹ️ You are already verified.')
-      .setFooter(FOOTER);
-    try { await interaction.reply({ embeds: [embed], ephemeral: true }); } catch {}
-    return;
-  }
+  if (
+    interaction.customId === VERIFY_LANG_EN_ID ||
+    interaction.customId === VERIFY_LANG_DE_ID
+  ) {
+    const lang = interaction.customId === VERIFY_LANG_DE_ID ? 'de' : 'en';
+    try {
+      await interaction.update(buildVerifyEmbedAndComponents(lang));
+      logger.info(`[verify] Sprache → ${lang.toUpperCase()}`);
+    } catch (err) {
+      logger.error('[verify] Fehler beim Umschalten der Sprache:', err);
+      return;
+    }
 
-  try {
-    await member.roles.add(VERIFY_ROLE_ID);
-    const embed = new EmbedBuilder()
-      .setColor(0x00ff00)
-      .setTitle('Verification')
-      .setDescription('✅ You are now verified!')
-      .setFooter(FOOTER);
-    await interaction.reply({ embeds: [embed], ephemeral: true });
-  } catch (err) {
-    logger.warn('[verifizierung] Rolle konnte nicht vergeben werden');
-    const embed = new EmbedBuilder()
-      .setColor(0xFFA500)
-      .setTitle('Verification')
-      .setDescription('⚠️ Verification failed. Please try again or contact staff.')
-      .setFooter(FOOTER);
-    try { await interaction.reply({ embeds: [embed], ephemeral: true }); } catch {}
+    const messageId = interaction.message.id;
+    if (verifyLangTimers.has(messageId)) {
+      clearTimeout(verifyLangTimers.get(messageId));
+    }
+    const timeout = setTimeout(async () => {
+      try {
+        await interaction.message.edit(buildVerifyEmbedAndComponents('en'));
+        logger.info('[verify] Sprache → EN (Timeout)');
+      } catch (err) {
+        logger.error('[verify] Fehler beim Zurücksetzen der Sprache:', err);
+      }
+      verifyLangTimers.delete(messageId);
+    }, VERIFY_RESET_MS);
+    verifyLangTimers.set(messageId, timeout);
   }
 }


### PR DESCRIPTION
## Summary
- add language toggle buttons and reset timer to verify message
- handle verification role assignment with English responses
- ensure verify message renders in English on startup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b86add6670832d802dd083523e13e3