### PR TITLE
feat: add voice stats updater

### DIFF
--- a/src/events/ready/handler.js
+++ b/src/events/ready/handler.js
@@ -4,6 +4,7 @@
 import ensureVerifyMessage from '../../modules/verify/ensure.js';
 import { ensureRulesMessage } from '../../modules/rules/ensure.js';
 import { ensureTeamMessage } from '../../modules/teamlist/ensure.js';
+import { startVoiceStats } from '../../modules/voiceStats/updater.js';
 import { logger } from '../../util/logger.js';
 
 export default {
@@ -25,6 +26,11 @@ export default {
       await ensureTeamMessage(client);
     } catch (err) {
       logger.error('[team] Fehler beim Sicherstellen der Nachricht:', err);
+    }
+    try {
+      await startVoiceStats(client);
+    } catch (err) {
+      logger.error('[voicestats] Fehler beim Starten:', err);
     }
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -15,9 +15,10 @@ const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildMembers,
+    GatewayIntentBits.GuildPresences,
     GatewayIntentBits.GuildMessages, // Kein Message-Content-Intent nötig
   ],
-}); // SERVER MEMBERS INTENT im Dev-Portal aktivieren
+}); // SERVER MEMBERS & PRESENCE INTENTS im Dev-Portal aktivieren
 
 const shutdown = (code = 0) => {
   logger.info('[beenden] Fahre herunter…');

--- a/src/modules/voiceStats/config.js
+++ b/src/modules/voiceStats/config.js
@@ -1,0 +1,5 @@
+export const VOICESTATS_GUILD_ID = process.env.GUILD_ID;         // optional, falls nur 1 Guild
+export const MEMBERS_CHANNEL_ID = "1355272570848673895";         // 👥 Mitglieder
+export const ONLINE_CHANNEL_ID  = "1355272617791193389";         // 🟢 Online
+export const UPDATE_EVERY_MS    = 300000;                        // 5 Minuten
+export const ONLINE_STATUSES    = ["online", "idle", "dnd"];     // was als „online“ zählt

--- a/src/modules/voiceStats/updater.js
+++ b/src/modules/voiceStats/updater.js
@@ -1,0 +1,68 @@
+/*
+### Zweck: Aktualisiert Voice-Statistik-Kanäle für Mitglieder- und Onlinezahlen.
+Der Bot benötigt in den Ziel-Kanälen die Berechtigung „Manage Channels“ zum Umbenennen.
+*/
+import { VOICESTATS_GUILD_ID, MEMBERS_CHANNEL_ID, ONLINE_CHANNEL_ID, UPDATE_EVERY_MS, ONLINE_STATUSES } from './config.js';
+import { logger } from '../../util/logger.js';
+
+let client;
+let intervalStarted = false;
+
+async function computeCounts(guild) {
+  await guild.members.fetch();
+  const humans = guild.members.cache.filter((m) => !m.user.bot).size;
+  await guild.members.fetch({ withPresences: true });
+  const online = guild.members.cache.filter(
+    (m) => !m.user.bot && m.presence && ONLINE_STATUSES.includes(m.presence.status)
+  ).size;
+  return { humans, online };
+}
+
+async function setChannelName(channelId, name) {
+  try {
+    const ch = await client.channels.fetch(channelId);
+    if (!ch) {
+      logger.warn(`[voicestats] Kanal nicht gefunden: ${channelId}`);
+      return;
+    }
+    if (ch.name !== name) {
+      await ch.setName(name);
+    }
+  } catch (err) {
+    logger.error('[voicestats] Fehler beim Umbenennen des Kanals:', err);
+  }
+}
+
+async function tick() {
+  const guild = VOICESTATS_GUILD_ID
+    ? client.guilds.cache.get(VOICESTATS_GUILD_ID)
+    : client.guilds.cache.first();
+  if (!guild) {
+    logger.warn('[voicestats] Guild nicht gefunden');
+    return;
+  }
+  const { humans, online } = await computeCounts(guild);
+  await setChannelName(MEMBERS_CHANNEL_ID, `👥 Mitglieder: ${humans}`);
+  await setChannelName(ONLINE_CHANNEL_ID, `🟢 Online: ${online}`);
+}
+
+export async function startVoiceStats(c) {
+  if (intervalStarted) return;
+  intervalStarted = true;
+  client = c;
+  try {
+    await tick();
+  } catch (err) {
+    logger.error('[voicestats] Fehler beim Aktualisieren der Voice-Stats:', err);
+  }
+  const interval = setInterval(async () => {
+    try {
+      await tick();
+    } catch (err) {
+      logger.error('[voicestats] Fehler beim Aktualisieren der Voice-Stats:', err);
+    }
+  }, UPDATE_EVERY_MS);
+  const stop = () => clearInterval(interval);
+  process.on('SIGTERM', stop);
+  process.on('SIGINT', stop);
+}


### PR DESCRIPTION
## Summary
- enable presence intent and note required permissions
- add voice stats module that updates member and online counts
- start voice stats updater on ready

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb00d18c2c832d84780ee53f3cc3dd