### PR TITLE
feat: add ticket panel and interactions

### DIFF
--- a/src/events/interactionCreate/handler.js
+++ b/src/events/interactionCreate/handler.js
@@ -12,8 +12,11 @@ import {
   MENU_CUSTOM_ID,
   BTN_CLAIM_ID,
   BTN_CLOSE_ID,
+  BTN_CLOSE_CONFIRM_ID,
+  BTN_REOPEN_ID,
   BTN_DELETE_ID,
-  BTN_ACK_PRIVATE_ID,
+  BTN_DELETE_CONFIRM_ID,
+  MODAL_REOPEN_ID,
 } from '../../modules/tickets/config.js';
 import { handleTicketInteractions } from '../../modules/tickets/interactions.js';
 
@@ -27,8 +30,19 @@ export default {
     }
     if (
       interaction.isButton() &&
-      [BTN_CLAIM_ID, BTN_CLOSE_ID, BTN_DELETE_ID, BTN_ACK_PRIVATE_ID].includes(interaction.customId)
+      [
+        BTN_CLAIM_ID,
+        BTN_CLOSE_ID,
+        BTN_CLOSE_CONFIRM_ID,
+        BTN_REOPEN_ID,
+        BTN_DELETE_ID,
+        BTN_DELETE_CONFIRM_ID,
+      ].includes(interaction.customId)
     ) {
+      await handleTicketInteractions(interaction, client);
+      return;
+    }
+    if (interaction.isModalSubmit() && interaction.customId === MODAL_REOPEN_ID) {
       await handleTicketInteractions(interaction, client);
       return;
     }

--- a/src/modules/tickets/config.js
+++ b/src/modules/tickets/config.js
@@ -1,21 +1,25 @@
-/*
-  Bot braucht: ManageChannels, ViewChannel, SendMessages, ReadMessageHistory, AddReactions (optional).
-  Für Pings: MentionEveryone nicht nötig, aber allowedMentions setzen.
-*/
+export const TICKET_PANEL_CHANNEL_ID    = "1354917224669773895"; // "Create Ticket"
+export const TICKET_PANEL_MESSAGE_ID    = "1413607006736220311"; // bestehende Panel-Message
+export const TICKET_ACTIVE_CATEGORY_ID  = "1357069606455345483"; // Aktive Tickets
+export const TICKET_ARCHIVE_CATEGORY_ID = "1357069661505589268"; // Archiv-Tickets
+export const TEAM_ROLE_ID               = "1354916696527208693"; // Team
 
-export const TICKET_PANEL_CHANNEL_ID   = "1354917224669773895";    // "Create Ticket"
-export const TICKET_PANEL_MESSAGE_ID   = "";                       // hier die Panel-Message-ID eintragen, falls bekannt
-export const TICKET_ACTIVE_CATEGORY_ID = "1357069606455345483";    // aktive Tickets
-export const TICKET_ARCHIVE_CATEGORY_ID = "1357069661505589268";   // Archiv-Kategorie-ID
-export const TEAM_ROLE_ID              = "1354916696527208693";    // "Team"
+export const MENU_CUSTOM_ID             = "ticket_menu";
+export const MENU_PLACEHOLDER           = "Create Ticket";
+export const MENU_OPTION_SUPPORT        = {
+  value: "support",
+  label: "Support",
+  description: "General questions & problems | Allgemeine Fragen & Probleme",
+  emoji: "🆘",
+};
 
-export const MENU_CUSTOM_ID            = "ticket_menu";
-export const MENU_PLACEHOLDER          = "Create Ticket";
-export const MENU_OPTION_SUPPORT       = { label: "Support", value: "support", emoji: "🆘" };
+export const BTN_CLAIM_ID               = "ticket_claim";
+export const BTN_CLOSE_ID               = "ticket_close";
+export const BTN_CLOSE_CONFIRM_ID       = "ticket_close_confirm";
+export const BTN_REOPEN_ID              = "ticket_reopen";
+export const MODAL_REOPEN_ID            = "ticket_reopen_modal";
+export const MODAL_REOPEN_REASON_ID     = "ticket_reopen_reason";
+export const BTN_DELETE_ID              = "ticket_delete";
+export const BTN_DELETE_CONFIRM_ID      = "ticket_delete_confirm";
 
-export const BTN_CLAIM_ID              = "ticket_claim";
-export const BTN_CLOSE_ID              = "ticket_close";
-export const BTN_DELETE_ID             = "ticket_delete";
-export const BTN_ACK_PRIVATE_ID        = "ticket_ack_private";     // "Privat wieder bestätigen"
-
-export const TICKET_CHANNEL_PREFIX     = "ticket";
+export const TICKET_CHANNEL_PREFIX      = "ticket";

--- a/src/modules/tickets/interactions.js
+++ b/src/modules/tickets/interactions.js
@@ -2,116 +2,169 @@ import {
   MENU_CUSTOM_ID,
   BTN_CLAIM_ID,
   BTN_CLOSE_ID,
+  BTN_CLOSE_CONFIRM_ID,
+  BTN_REOPEN_ID,
+  MODAL_REOPEN_ID,
+  MODAL_REOPEN_REASON_ID,
   BTN_DELETE_ID,
-  BTN_ACK_PRIVATE_ID,
+  BTN_DELETE_CONFIRM_ID,
+  TICKET_ACTIVE_CATEGORY_ID,
   TICKET_ARCHIVE_CATEGORY_ID,
 } from './config.js';
 import { openTicket } from './open.js';
-import { isTeam } from './utils.js';
+import { isTeam, setStatusPrefix } from './utils.js';
 import { FOOTER } from '../../util/footer.js';
 import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
   EmbedBuilder,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
 } from 'discord.js';
 
 export async function handleTicketInteractions(interaction, client) {
   if (interaction.isStringSelectMenu() && interaction.customId === MENU_CUSTOM_ID) {
-    await interaction.deferReply({ ephemeral: true });
-    const success = await openTicket(interaction);
-    if (success) {
-      await interaction.deleteReply().catch(() => {});
+    const value = interaction.values?.[0];
+    if (value === 'support') {
+      await openTicket(interaction);
     }
     return;
   }
 
-  if (!interaction.isButton()) return;
-
-  if (interaction.customId === BTN_CLAIM_ID) {
-    if (!isTeam(interaction.member)) {
-      await interaction.reply({ content: '```Kein Teammitglied```', ephemeral: true });
-      return;
-    }
-    await interaction.deferUpdate();
-
-    const embed = EmbedBuilder.from(interaction.message.embeds[0]);
-    embed.data.fields = embed.data.fields.map((f) =>
-      f.name === 'Status'
-        ? {
-            ...f,
-            value: `🟢 Claimed by <@${interaction.user.id}> / 🟢 Übernommen von <@${interaction.user.id}>`,
-          }
-        : f
-    );
-    await interaction.message.edit({ embeds: [embed] });
-
-    const info = new EmbedBuilder()
-      .setDescription(`Claimed by <@${interaction.user.id}>\nÜbernommen von <@${interaction.user.id}>`)
-      .setFooter(FOOTER);
-    await interaction.channel.send({ embeds: [info] });
-    return;
-  }
-
-  if (interaction.customId === BTN_CLOSE_ID) {
-    await interaction.reply({ content: '```Schließen```', ephemeral: true });
-
-    if (TICKET_ARCHIVE_CATEGORY_ID) {
-      try {
-        await interaction.channel.setParent(TICKET_ARCHIVE_CATEGORY_ID);
-      } catch {}
-    } else {
-      const createdField = interaction.message.embeds[0]?.fields?.find((f) => f.name === 'Created by');
-      const openerId = createdField?.value.match(/<@(\d+)>/)?.[1];
-      if (openerId) {
-        try {
-          await interaction.channel.permissionOverwrites.edit(openerId, { SendMessages: false });
-        } catch {}
+  if (interaction.isButton()) {
+    switch (interaction.customId) {
+      case BTN_CLAIM_ID: {
+        if (!isTeam(interaction.member)) {
+          await interaction.reply({ content: '```Kein Teammitglied```', ephemeral: true, allowedMentions: { parse: [] } });
+          return;
+        }
+        await interaction.deferUpdate();
+        const embed = EmbedBuilder.from(interaction.message.embeds[0]);
+        embed.data.fields = embed.data.fields.map((f) =>
+          f.name === 'Status'
+            ? { ...f, value: `🟢 Claimed by <@${interaction.user.id}> | 🟢 Übernommen von <@${interaction.user.id}>` }
+            : f
+        );
+        await interaction.message.edit({ embeds: [embed], allowedMentions: { parse: [] } });
+        await setStatusPrefix(interaction.channel, '🟢 ');
+        const info = new EmbedBuilder()
+          .setDescription(`Claimed by <@${interaction.user.id}> | Übernommen von <@${interaction.user.id}>`)
+          .setFooter(FOOTER);
+        await interaction.channel.send({ embeds: [info], allowedMentions: { parse: [] } });
+        return;
       }
+      case BTN_CLOSE_ID: {
+        const confirmBtn = new ButtonBuilder()
+          .setCustomId(BTN_CLOSE_CONFIRM_ID)
+          .setLabel('Bestätigen')
+          .setStyle(ButtonStyle.Danger);
+        const row = new ActionRowBuilder().addComponents(confirmBtn);
+        await interaction.reply({ content: '```Schließen```', components: [row], ephemeral: true, allowedMentions: { parse: [] } });
+        return;
+      }
+      case BTN_CLOSE_CONFIRM_ID: {
+        let startMsg;
+        try {
+          const messages = await interaction.channel.messages.fetch({ limit: 20 });
+          startMsg = messages.find((m) =>
+            m.author.id === client.user.id &&
+            m.components.some((row) => row.components.some((c) => [BTN_CLAIM_ID, BTN_CLOSE_ID, BTN_REOPEN_ID].includes(c.customId)))
+          );
+        } catch {}
+        if (TICKET_ARCHIVE_CATEGORY_ID) {
+          try { await interaction.channel.setParent(TICKET_ARCHIVE_CATEGORY_ID); } catch {}
+        }
+        if (startMsg) {
+          const embed = EmbedBuilder.from(startMsg.embeds[0]);
+          embed.data.fields = embed.data.fields.map((f) =>
+            f.name === 'Status' ? { ...f, value: '🔴 Closed | 🔴 Geschlossen' } : f
+          );
+          const reopenBtn = new ButtonBuilder()
+            .setCustomId(BTN_REOPEN_ID)
+            .setLabel('Reopen')
+            .setStyle(ButtonStyle.Secondary);
+          const deleteBtn = new ButtonBuilder()
+            .setCustomId(BTN_DELETE_ID)
+            .setLabel('Delete')
+            .setStyle(ButtonStyle.Danger);
+          const row = new ActionRowBuilder().addComponents(reopenBtn, deleteBtn);
+          await startMsg.edit({ embeds: [embed], components: [row], allowedMentions: { parse: [] } });
+        }
+        await setStatusPrefix(interaction.channel, '🔴 ');
+        await interaction.update({ content: '```Schließen```', components: [], ephemeral: true, allowedMentions: { parse: [] } });
+        return;
+      }
+      case BTN_REOPEN_ID: {
+        const modal = new ModalBuilder()
+          .setCustomId(MODAL_REOPEN_ID)
+          .setTitle('Reopen Ticket');
+        const input = new TextInputBuilder()
+          .setCustomId(MODAL_REOPEN_REASON_ID)
+          .setLabel('Reason | Grund')
+          .setStyle(TextInputStyle.Short)
+          .setRequired(true)
+          .setMaxLength(256);
+        modal.addComponents(new ActionRowBuilder().addComponents(input));
+        await interaction.showModal(modal);
+        return;
+      }
+      case BTN_DELETE_ID: {
+        if (!isTeam(interaction.member)) {
+          await interaction.reply({ content: '```Kein Teammitglied```', ephemeral: true, allowedMentions: { parse: [] } });
+          return;
+        }
+        const confirmBtn = new ButtonBuilder()
+          .setCustomId(BTN_DELETE_CONFIRM_ID)
+          .setLabel('Bestätigen')
+          .setStyle(ButtonStyle.Danger);
+        const row = new ActionRowBuilder().addComponents(confirmBtn);
+        await interaction.reply({ content: '```Löschen```', components: [row], ephemeral: true, allowedMentions: { parse: [] } });
+        return;
+      }
+      case BTN_DELETE_CONFIRM_ID: {
+        await interaction.update({ content: '```Löschen```', components: [], ephemeral: true, allowedMentions: { parse: [] } }).catch(() => {});
+        setTimeout(() => interaction.channel.delete().catch(() => {}), 5000);
+        return;
+      }
+      default:
+        return;
     }
+  }
 
-    const embed = EmbedBuilder.from(interaction.message.embeds[0]);
-    embed.data.fields = embed.data.fields.map((f) =>
-      f.name === 'Status' ? { ...f, value: '🔴 Closed / 🔴 Geschlossen' } : f
-    );
-
-    const deleteBtn = new ButtonBuilder()
-      .setCustomId(BTN_DELETE_ID)
-      .setLabel('Delete')
-      .setStyle(ButtonStyle.Danger)
-      .setEmoji('🗑️');
-    const ackBtn = new ButtonBuilder()
-      .setCustomId(BTN_ACK_PRIVATE_ID)
-      .setLabel('Privat wieder bestätigen')
-      .setStyle(ButtonStyle.Secondary)
-      .setEmoji('🔒');
-
-    const row = new ActionRowBuilder().addComponents(deleteBtn, ackBtn);
-    await interaction.message.edit({ embeds: [embed], components: [row] });
-
-    setTimeout(() => {
-      const disabledRow = new ActionRowBuilder().addComponents(
-        ButtonBuilder.from(deleteBtn).setDisabled(true),
-        ButtonBuilder.from(ackBtn).setDisabled(true)
+  if (interaction.isModalSubmit() && interaction.customId === MODAL_REOPEN_ID) {
+    const reason = interaction.fields.getTextInputValue(MODAL_REOPEN_REASON_ID);
+    let startMsg;
+    try {
+      const messages = await interaction.channel.messages.fetch({ limit: 20 });
+      startMsg = messages.find((m) =>
+        m.author.id === client.user.id &&
+        m.components.some((row) => row.components.some((c) => [BTN_CLAIM_ID, BTN_CLOSE_ID, BTN_REOPEN_ID].includes(c.customId)))
       );
-      interaction.message.edit({ components: [disabledRow] }).catch(() => {});
-    }, 5000);
-    return;
-  }
-
-  if (interaction.customId === BTN_ACK_PRIVATE_ID) {
-    await interaction.reply({ content: '```Privat wieder bestätigen```', ephemeral: true });
-    return;
-  }
-
-  if (interaction.customId === BTN_DELETE_ID) {
-    if (!isTeam(interaction.member)) {
-      await interaction.reply({ content: '```Kein Teammitglied```', ephemeral: true });
-      return;
+    } catch {}
+    try { await interaction.channel.setParent(TICKET_ACTIVE_CATEGORY_ID); } catch {}
+    await setStatusPrefix(interaction.channel, '');
+    if (startMsg) {
+      const embed = EmbedBuilder.from(startMsg.embeds[0]);
+      embed.data.fields = embed.data.fields.map((f) =>
+        f.name === 'Status' ? { ...f, value: 'Unclaimed | Nicht übernommen' } : f
+      );
+      const claimBtn = new ButtonBuilder().setCustomId(BTN_CLAIM_ID).setLabel('Claim').setStyle(ButtonStyle.Success);
+      const closeBtn = new ButtonBuilder().setCustomId(BTN_CLOSE_ID).setLabel('Close').setStyle(ButtonStyle.Danger);
+      const row = new ActionRowBuilder().addComponents(claimBtn, closeBtn);
+      await startMsg.edit({ embeds: [embed], components: [row], allowedMentions: { parse: [] } });
     }
-    await interaction.reply({ content: '```Löschen```', ephemeral: true });
-    setTimeout(() => {
-      interaction.channel.delete().catch(() => {});
-    }, 5000);
+    const info = new EmbedBuilder()
+      .setDescription(`Ticket reopened | Ticket wieder eröffnet — Reason/Grund: ${reason}`)
+      .setFooter(FOOTER);
+    await interaction.channel.send({
+      content: `<@${interaction.user.id}>`,
+      embeds: [info],
+      allowedMentions: { users: [interaction.user.id], parse: [] },
+    });
+    await interaction.deferReply({ ephemeral: true });
+    await interaction.deleteReply().catch(() => {});
+    return;
   }
 }

--- a/src/modules/tickets/open.js
+++ b/src/modules/tickets/open.js
@@ -16,11 +16,11 @@ import {
 } from 'discord.js';
 
 export async function openTicket(interaction) {
-  const { guild, user } = interaction;
+  const { guild, user, member } = interaction;
   const categoryId = TICKET_ACTIVE_CATEGORY_ID;
   if (!categoryId) {
-    await interaction.editReply('```Fehler```');
-    return false;
+    await interaction.reply({ content: '```Fehler```', ephemeral: true, allowedMentions: { parse: [] } });
+    return;
   }
 
   let name = buildTicketName(user);
@@ -29,10 +29,7 @@ export async function openTicket(interaction) {
   }
 
   const overwrites = [
-    {
-      id: guild.roles.everyone.id,
-      deny: [PermissionsBitField.Flags.ViewChannel],
-    },
+    { id: guild.roles.everyone.id, deny: [PermissionsBitField.Flags.ViewChannel] },
     {
       id: user.id,
       allow: [
@@ -70,17 +67,18 @@ export async function openTicket(interaction) {
       permissionOverwrites: overwrites,
     });
   } catch {
-    await interaction.editReply('```Fehler```');
-    return false;
+    await interaction.reply({ content: '```Fehler```', ephemeral: true, allowedMentions: { parse: [] } });
+    return;
   }
 
   const embed = new EmbedBuilder()
     .setTitle('🧾 Support Ticket | Support-Ticket')
     .setDescription(
-      `**English**\n• A team member will assist you shortly.\n\n**Deutsch**\n• Ein Teammitglied kümmert sich in Kürze.`
+      `**English**\n• A team member will assist you shortly.\n\n` +
+        `**Deutsch**\n• Ein Teammitglied kümmert sich in Kürze.`
     )
     .addFields(
-      { name: 'Status', value: 'Unclaimed / Nicht übernommen' },
+      { name: 'Status', value: 'Unclaimed | Nicht übernommen' },
       { name: 'Created by', value: `<@${user.id}>` }
     )
     .setFooter(FOOTER);
@@ -88,14 +86,12 @@ export async function openTicket(interaction) {
   const claimBtn = new ButtonBuilder()
     .setCustomId(BTN_CLAIM_ID)
     .setLabel('Claim')
-    .setStyle(ButtonStyle.Success)
-    .setEmoji('✅');
+    .setStyle(ButtonStyle.Success);
 
   const closeBtn = new ButtonBuilder()
     .setCustomId(BTN_CLOSE_ID)
     .setLabel('Close')
-    .setStyle(ButtonStyle.Danger)
-    .setEmoji('🔴');
+    .setStyle(ButtonStyle.Danger);
 
   const row = new ActionRowBuilder().addComponents(claimBtn, closeBtn);
 
@@ -106,5 +102,14 @@ export async function openTicket(interaction) {
     allowedMentions: { users: [user.id], roles: [TEAM_ROLE_ID], parse: [] },
   });
 
-  return true;
+  const replyEmbed = new EmbedBuilder()
+    .setTitle('Ticket created | Ticket erstellt')
+    .setFooter(FOOTER);
+
+  await interaction.reply({
+    content: `➡️ <#${channel.id}>\n\`\`\`Das Channel wurde erstellt und auch erwähnt\`\`\``,
+    embeds: [replyEmbed],
+    ephemeral: true,
+    allowedMentions: { parse: [] },
+  });
 }

--- a/src/modules/tickets/panel.js
+++ b/src/modules/tickets/panel.js
@@ -1,4 +1,9 @@
-import { EmbedBuilder, ActionRowBuilder, StringSelectMenuBuilder } from 'discord.js';
+import {
+  EmbedBuilder,
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuOptionBuilder,
+} from 'discord.js';
 import { FOOTER } from '../../util/footer.js';
 import { MENU_CUSTOM_ID, MENU_PLACEHOLDER, MENU_OPTION_SUPPORT } from './config.js';
 
@@ -6,14 +11,21 @@ export function buildTicketPanel() {
   const embed = new EmbedBuilder()
     .setTitle('🎫 Create Ticket — Support | Ticket erstellen — Support')
     .setDescription(
-      `**English**\n• Choose a category below to open a support ticket.\n\n**Deutsch**\n• Wähle unten eine Kategorie, um ein Support-Ticket zu eröffnen.`
+      `**English**\n• Choose a category below to open a support ticket.\n\n` +
+        `**Deutsch**\n• Wähle unten eine Kategorie, um ein Support-Ticket zu eröffnen.`
     )
     .setFooter(FOOTER);
+
+  const option = new StringSelectMenuOptionBuilder()
+    .setValue(MENU_OPTION_SUPPORT.value)
+    .setLabel(MENU_OPTION_SUPPORT.label)
+    .setDescription(MENU_OPTION_SUPPORT.description)
+    .setEmoji(MENU_OPTION_SUPPORT.emoji);
 
   const menu = new StringSelectMenuBuilder()
     .setCustomId(MENU_CUSTOM_ID)
     .setPlaceholder(MENU_PLACEHOLDER)
-    .addOptions(MENU_OPTION_SUPPORT);
+    .addOptions(option);
 
   const row = new ActionRowBuilder().addComponents(menu);
   return { embeds: [embed], components: [row] };

--- a/src/modules/tickets/utils.js
+++ b/src/modules/tickets/utils.js
@@ -15,3 +15,21 @@ export function buildTicketName(user) {
 export function isTeam(member) {
   return member.roles.cache.has(TEAM_ROLE_ID);
 }
+
+export async function setStatusPrefix(channel, symbol) {
+  if (!channel?.manageable) return;
+  const prefixes = ['🟢 ', '🔴 '];
+  let name = channel.name;
+  for (const p of prefixes) {
+    if (name.startsWith(p)) {
+      name = name.slice(p.length);
+      break;
+    }
+  }
+  const newName = symbol + name;
+  if (channel.name !== newName) {
+    try {
+      await channel.setName(newName);
+    } catch {}
+  }
+}


### PR DESCRIPTION
## Summary
- add configuration and panel builder for ticket system
- handle ticket open, claim, close, reopen and delete interactions
- wire interactionCreate to route ticket components

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68bbe68dc6f4832d864cb39c1d515a41