### PR TITLE
fix voice stats online counts and presences

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,9 +15,10 @@ const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildMembers,
+    GatewayIntentBits.GuildPresences,
     GatewayIntentBits.GuildMessages, // Kein Message-Content-Intent nötig
   ],
-}); // SERVER MEMBERS INTENT im Dev-Portal aktivieren
+}); // SERVER MEMBERS + PRESENCE INTENTS im Dev-Portal aktivieren
 
 const shutdown = (code = 0) => {
   logger.info('[beenden] Fahre herunter…');

--- a/src/modules/voiceStats/config.js
+++ b/src/modules/voiceStats/config.js
@@ -1,3 +1,4 @@
+// Der Bot benötigt GuildMembers- und GuildPresences-Intents (siehe index.js)
 export const VOICESTATS_GUILD_ID = process.env.GUILD_ID;         // optional, falls nur 1 Guild
 export const MEMBERS_CHANNEL_ID = "1355272570848673895";         // 👥 Mitglieder
 export const ONLINE_CHANNEL_ID  = "1355272617791193389";         // 🟢 Online

--- a/src/modules/voiceStats/updater.js
+++ b/src/modules/voiceStats/updater.js
@@ -2,18 +2,30 @@
 ### Zweck: Aktualisiert Voice-Statistik-Kanäle für Mitglieder- und Onlinezahlen.
 Der Bot benötigt in den Ziel-Kanälen die Berechtigung „Manage Channels“ zum Umbenennen.
 */
-import { VOICESTATS_GUILD_ID, MEMBERS_CHANNEL_ID, ONLINE_CHANNEL_ID, UPDATE_EVERY_MS, ONLINE_STATUSES } from './config.js';
+import {
+  VOICESTATS_GUILD_ID,
+  MEMBERS_CHANNEL_ID,
+  ONLINE_CHANNEL_ID,
+  UPDATE_EVERY_MS,
+  ONLINE_STATUSES,
+} from './config.js';
 import { logger } from '../../util/logger.js';
 
 let client;
 let intervalStarted = false;
+let presencesFetched = false;
 
 async function computeCounts(guild) {
-  await guild.members.fetch();
+  if (!presencesFetched) {
+    await guild.members.fetch({ withPresences: true });
+    presencesFetched = true;
+  }
   const humans = guild.members.cache.filter((m) => !m.user.bot).size;
-  await guild.members.fetch({ withPresences: true });
   const online = guild.members.cache.filter(
-    (m) => !m.user.bot && m.presence && ONLINE_STATUSES.includes(m.presence.status)
+    (m) =>
+      !m.user.bot &&
+      m.presence &&
+      ONLINE_STATUSES.includes(m.presence.status)
   ).size;
   return { humans, online };
 }


### PR DESCRIPTION
## Summary
- ensure online stats count only human members
- fetch member presences once and reuse cache
- request GuildPresences intent at startup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc647fe844832d80c4bf1219c60c32