### PR TITLE
refactor: revamp ticket flows

### DIFF
--- a/src/modules/tickets/interactions.js
+++ b/src/modules/tickets/interactions.js
@@ -45,7 +45,10 @@ export async function handleTicketInteractions(interaction, client) {
       const embed = EmbedBuilder.from(interaction.message.embeds[0]);
       embed.data.fields = embed.data.fields.map((f) =>
         f.name === 'Status'
-          ? { ...f, value: `✅ Claimed by <@${interaction.user.id}> | ✅ Übernommen von <@${interaction.user.id}>` }
+          ? {
+              ...f,
+              value: `🇺🇸 Claimed by <@${interaction.user.id}>\n🇩🇪 Übernommen von <@${interaction.user.id}>`,
+            }
           : f
       );
       await interaction.message.edit({
@@ -53,9 +56,11 @@ export async function handleTicketInteractions(interaction, client) {
         components: interaction.message.components,
         allowedMentions: { parse: [] },
       });
-      await setStatusPrefix(interaction.channel, '✅ ');
+      await setStatusPrefix(interaction.channel, 'claimed');
       const info = new EmbedBuilder()
-        .setDescription(`✅ Claimed by <@${interaction.user.id}> | ✅ Übernommen von <@${interaction.user.id}>`)
+        .setDescription(
+          `🇺🇸 Claimed by <@${interaction.user.id}>\n🇩🇪 Übernommen von <@${interaction.user.id}>`
+        )
         .setFooter(FOOTER);
       await interaction.channel.send({ embeds: [info], allowedMentions: { parse: [] } });
       return;
@@ -65,11 +70,11 @@ export async function handleTicketInteractions(interaction, client) {
         .setCustomId(BTN_CLOSE_CONFIRM_ID)
         .setLabel('Confirm')
         .setEmoji('✅')
-        .setStyle(ButtonStyle.Danger);
+        .setStyle(ButtonStyle.Primary);
       const row = new ActionRowBuilder().addComponents(btn);
       await interaction.reply({
         content:
-          'Are you sure you want to close this ticket? | Bist du sicher, dass du dieses Ticket schließen möchtest?',
+          '🇺🇸 Are you sure you want to close this ticket?\n🇩🇪 Bist du sicher, dass du dieses Ticket schließen möchtest?',
         components: [row],
         ephemeral: true,
         allowedMentions: { parse: [] },
@@ -96,7 +101,9 @@ export async function handleTicketInteractions(interaction, client) {
       if (startMsg) {
         const embed = EmbedBuilder.from(startMsg.embeds[0]);
         embed.data.fields = embed.data.fields.map((f) =>
-          f.name === 'Status' ? { ...f, value: '🔴 Closed | 🔴 Geschlossen' } : f
+          f.name === 'Status'
+            ? { ...f, value: '🇺🇸 Ticket archived\n🇩🇪 Ticket archiviert' }
+            : f
         );
         const reopenBtn = new ButtonBuilder()
           .setCustomId(BTN_REOPEN_ID)
@@ -111,9 +118,9 @@ export async function handleTicketInteractions(interaction, client) {
         const row = new ActionRowBuilder().addComponents(reopenBtn, deleteBtn);
         await startMsg.edit({ embeds: [embed], components: [row], allowedMentions: { parse: [] } });
       }
-      await setStatusPrefix(interaction.channel, '🔴 ');
+      await setStatusPrefix(interaction.channel, 'closed');
       await interaction.update({
-        content: 'Ticket archived | Ticket archiviert',
+        content: '🇺🇸 Ticket archived\n🇩🇪 Ticket archiviert',
         components: [],
         allowedMentions: { parse: [] },
       });
@@ -124,10 +131,10 @@ export async function handleTicketInteractions(interaction, client) {
         .setCustomId(BTN_REOPEN_CONFIRM_ID)
         .setLabel('Confirm')
         .setEmoji('✅')
-        .setStyle(ButtonStyle.Success);
+        .setStyle(ButtonStyle.Primary);
       const row = new ActionRowBuilder().addComponents(btn);
       await interaction.reply({
-        content: 'Reopen this ticket? | Dieses Ticket wieder eröffnen?',
+        content: '🇺🇸 Reopen this ticket?\n🇩🇪 Dieses Ticket wieder eröffnen?',
         components: [row],
         ephemeral: true,
         allowedMentions: { parse: [] },
@@ -151,7 +158,7 @@ export async function handleTicketInteractions(interaction, client) {
           await interaction.channel.setParent(TICKET_ACTIVE_CATEGORY_ID);
         } catch {}
       }
-      await setStatusPrefix(interaction.channel, '');
+      await setStatusPrefix(interaction.channel, 'neutral');
       if (startMsg) {
         const embed = EmbedBuilder.from(startMsg.embeds[0]);
         embed.data.fields = embed.data.fields.map((f) =>
@@ -175,11 +182,7 @@ export async function handleTicketInteractions(interaction, client) {
           '🔓 Ticket reopened | 🔓 Ticket wieder eröffnet\n• Please describe your issue. | Bitte beschreibe dein Anliegen.'
         )
         .setFooter(FOOTER);
-      await interaction.channel.send({
-        content: `<@${interaction.user.id}>`,
-        embeds: [info],
-        allowedMentions: { users: [interaction.user.id], parse: [] },
-      });
+      await interaction.channel.send({ embeds: [info], allowedMentions: { parse: [] } });
       await interaction.update({
         content: 'Reopened | Wieder eröffnet',
         components: [],
@@ -196,7 +199,7 @@ export async function handleTicketInteractions(interaction, client) {
       const row = new ActionRowBuilder().addComponents(btn);
       await interaction.reply({
         content:
-          'Are you sure you want to delete this ticket? | Bist du sicher, dass du dieses Ticket löschen möchtest?',
+          '🇺🇸 Are you sure you want to delete this ticket?\n🇩🇪 Bist du sicher, dass du dieses Ticket löschen möchtest?',
         components: [row],
         ephemeral: true,
         allowedMentions: { parse: [] },
@@ -205,7 +208,7 @@ export async function handleTicketInteractions(interaction, client) {
     }
     case BTN_DELETE_CONFIRM_ID: {
       await interaction.update({
-        content: 'Deleting in 5 seconds… | Löschen in 5 Sekunden…',
+        content: '🇺🇸 Deleting in 5 seconds…\n🇩🇪 Löschen in 5 Sekunden…',
         components: [],
         allowedMentions: { parse: [] },
       });

--- a/src/modules/tickets/open.js
+++ b/src/modules/tickets/open.js
@@ -74,7 +74,8 @@ export async function openTicket(interaction) {
   const embed = new EmbedBuilder()
     .setTitle('🧾 Support Ticket | Support-Ticket')
     .setDescription(
-      `Please describe your issue while you wait. | Bitte beschreibe dein Anliegen, während du wartest.\n\n` +
+      `🇺🇸 Please describe your issue while you’re waiting.\n` +
+        `🇩🇪 Bitte beschreibe dein Anliegen, während du wartest.\n\n` +
         `**English**\n• A team member will assist you shortly.\n\n` +
         `**Deutsch**\n• Ein Teammitglied kümmert sich in Kürze.`
     )
@@ -107,7 +108,7 @@ export async function openTicket(interaction) {
 
   const ticketChannel = channel.toString();
   await interaction.reply({
-    content: `➡️ ${ticketChannel} — Ticket created | Ticket erstellt`,
+    content: `➡️ ${ticketChannel}\n🇺🇸 Ticket created\n🇩🇪 Ticket erstellt`,
     ephemeral: true,
     allowedMentions: { parse: [] },
   });

--- a/src/modules/tickets/utils.js
+++ b/src/modules/tickets/utils.js
@@ -16,10 +16,13 @@ export function isTeam(member) {
   return member.roles.cache.has(TEAM_ROLE_ID);
 }
 
-export async function setStatusPrefix(channel, symbol) {
+export async function setStatusPrefix(channel, mode) {
   if (!channel?.manageable) return;
-  const base = channel.name.replace(/^(?:✅ |🔴 )/, '');
-  const newName = symbol ? `${symbol}${base}` : base;
+  const base = channel.name.replace(/^(?:✅\s|🔴-)+/, '');
+  let prefix = '';
+  if (mode === 'claimed') prefix = '✅ ';
+  if (mode === 'closed') prefix = '🔴-';
+  const newName = `${prefix}${base}`;
   if (channel.name !== newName) {
     try {
       await channel.setName(newName);


### PR DESCRIPTION
## Summary
- refine status prefix handling to enforce neutral/claimed/closed states
- add bilingual guidance on ticket creation
- streamline claim/close/reopen/delete flows with clear confirmations

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6d740978832d867dafd2f1c44839