### PR TITLE
feat: sequential ticket channel naming

### DIFF
--- a/src/modules/tickets/open.js
+++ b/src/modules/tickets/open.js
@@ -1,4 +1,10 @@
-import { BTN_CLAIM_ID, BTN_CLOSE_ID, TEAM_ROLE_ID, TICKET_ACTIVE_CATEGORY_ID } from './config.js';
+import {
+  BTN_CLAIM_ID,
+  BTN_CLOSE_ID,
+  TEAM_ROLE_ID,
+  TICKET_ACTIVE_CATEGORY_ID,
+  TICKET_CHANNEL_PREFIX,
+} from './config.js';
 import { buildTicketName } from './utils.js';
 import { FOOTER } from '../../util/embeds/footer.js';
 import { applyAuthor } from '../../util/embeds/author.js';
@@ -20,10 +26,14 @@ export async function openTicket(interaction, lang = 'en') {
     return;
   }
 
-  let name = buildTicketName(user);
-  if (guild.channels.cache.some((c) => c.name === name)) {
-    name += `-${Math.floor(Math.random() * 9000) + 1000}`;
-  }
+  const existing = guild.channels.cache.filter(
+    (c) =>
+      c.parentId === TICKET_ACTIVE_CATEGORY_ID && c.name.startsWith(TICKET_CHANNEL_PREFIX)
+  );
+  const index = Math.min(existing.size + 1, 99);
+
+  let name = buildTicketName(user, index);
+  // keine Zufallsnummern mehr nötig
 
   const overwrites = [
     { id: guild.roles.everyone.id, deny: [PermissionsBitField.Flags.ViewChannel] },

--- a/src/modules/tickets/utils.js
+++ b/src/modules/tickets/utils.js
@@ -8,8 +8,10 @@ export function slugUsername(name) {
     .replace(/^-|-$/g, '');
 }
 
-export function buildTicketName(user) {
-  return `${TICKET_CHANNEL_PREFIX}-${slugUsername(user.username)}`;
+export function buildTicketName(user, index) {
+  return `${TICKET_CHANNEL_PREFIX}-${slugUsername(user.username)}-${index
+    .toString()
+    .padStart(2, '0')}`;
 }
 
 export function isTeam(member) {


### PR DESCRIPTION
## Summary
- number ticket channels sequentially and remove random suffix
- incorporate 2-digit index into ticket channel names

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b2d11fb0832d9e838b5f2b726cbd