### PR TITLE
chore: set up lint script and logger test

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,11 @@
+export default [
+  {
+    files: ['**/*.js'],
+    ignores: ['node_modules/**'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {},
+  },
+];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Discord Projekt",
   "main": "src/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint .",
+    "test": "vitest",
     "dev": "nodemon src/index.js",
     "start": "node src/index.js",
     "prestart": "node scripts/register-guild-commands.js"
@@ -16,7 +17,10 @@
     "discord.js": "^14.22.1"
   },
   "devDependencies": {
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "eslint": "^8.57.0",
+    "prettier": "^3.3.2",
+    "vitest": "^1.5.0"
   },
   "type": "module",
     "engines": {

--- a/src/util/logger.test.js
+++ b/src/util/logger.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('logger', () => {
+  it('logs only above set level', async () => {
+    process.env.LOG_LEVEL = 'warn';
+    vi.resetModules();
+    const { logger } = await import('./logger.js');
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    logger.debug('debug');
+    logger.info('info');
+    logger.warn('warn');
+    logger.error('error');
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith('warn');
+    expect(errorSpy).toHaveBeenCalledWith('error');
+
+    vi.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
## Summary
- configure ESLint via flat config and add lint script
- add Vitest-based unit test for logger utility

## Testing
- `npm run lint`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b5953278832dbe7d5ad53ccb31b9