### PR TITLE
Wrap event handlers with error logging

### DIFF
--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -26,21 +26,30 @@ export default async function eventLoader(client) {
 
     if (file) {
       const filePath = path.join(dir, file);
-        try {
-          const mod = (await import(filePath)).default;
-          if (!mod?.name || typeof mod.execute !== 'function') {
-            logger.warn(`[ereignisse] Überspringe ${path.relative(baseDir, filePath)}: name/execute fehlt`);
-            return;
-          }
-          if (mod.once) {
-            client.once(mod.name, (...args) => mod.execute(...args, client));
-          } else {
-            client.on(mod.name, (...args) => mod.execute(...args, client));
-          }
-          loaded++;
-        } catch (err) {
-          logger.warn(`[ereignisse] Laden von ${filePath} fehlgeschlagen:`, err);
+      try {
+        const mod = (await import(filePath)).default;
+        if (!mod?.name || typeof mod.execute !== 'function') {
+          logger.warn(`[ereignisse] Überspringe ${path.relative(baseDir, filePath)}: name/execute fehlt`);
+          return;
         }
+
+        const handler = async (...args) => {
+          try {
+            await mod.execute(...args, client);
+          } catch (err) {
+            logger.error(`[ereignisse] Fehler im Handler ${mod.name}:`, err);
+          }
+        };
+
+        if (mod.once) {
+          client.once(mod.name, handler);
+        } else {
+          client.on(mod.name, handler);
+        }
+        loaded++;
+      } catch (err) {
+        logger.warn(`[ereignisse] Laden von ${filePath} fehlgeschlagen:`, err);
+      }
     } else {
       for (const entry of entries.filter((e) => e.isDirectory())) {
         await traverse(path.join(dir, entry.name));

--- a/src/loaders/eventLoader.test.js
+++ b/src/loaders/eventLoader.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+const failingEventModule = `export default {
+  name: 'failingEvent',
+  once: false,
+  async execute() {
+    throw new Error('handler failed');
+  },
+};`;
+
+describe('eventLoader', () => {
+  it('logs errors thrown by event handlers', async () => {
+    const tempBase = await mkdtemp(path.join(tmpdir(), 'event-loader-'));
+    const eventsDir = path.join(tempBase, 'src', 'events', 'failing');
+    await mkdir(eventsDir, { recursive: true });
+    const handlerPath = path.join(eventsDir, 'handler.js');
+    await writeFile(handlerPath, failingEventModule);
+
+    const client = { on: vi.fn(), once: vi.fn() };
+    let errorSpy;
+    let cwdSpy;
+
+    try {
+      vi.resetModules();
+      cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempBase);
+      const { logger } = await import('../util/logger.js');
+      errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+      const { default: eventLoader } = await import('./eventLoader.js');
+      await eventLoader(client);
+
+      expect(client.on).toHaveBeenCalledTimes(1);
+      const [eventName, handler] = client.on.mock.calls[0];
+      expect(eventName).toBe('failingEvent');
+
+      await handler();
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toContain('failingEvent');
+    } finally {
+      await rm(tempBase, { recursive: true, force: true });
+      errorSpy?.mockRestore();
+      cwdSpy?.mockRestore();
+      vi.restoreAllMocks();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- wrap dynamically loaded event handlers in an async wrapper that logs failures with the event name
- add a Vitest covering a failing handler to ensure logger.error is invoked

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c95e2ce898832d9c94ada0b813b83e