### PR TITLE
Use error logging for loader import failures

### DIFF
--- a/src/loaders/commandLoader.js
+++ b/src/loaders/commandLoader.js
@@ -42,7 +42,7 @@ export default async function commandLoader(client) {
           );
         }
       } catch (err) {
-        logger.warn(`[befehle] Laden von ${filePath} fehlgeschlagen:`, err);
+        logger.error(`[befehle] Laden von ${filePath} fehlgeschlagen:`, err);
       }
     } else {
       for (const entry of entries.filter((e) => e.isDirectory())) {

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -48,7 +48,7 @@ export default async function eventLoader(client) {
         }
         loaded++;
       } catch (err) {
-        logger.warn(`[ereignisse] Laden von ${filePath} fehlgeschlagen:`, err);
+        logger.error(`[ereignisse] Laden von ${filePath} fehlgeschlagen:`, err);
       }
     } else {
       for (const entry of entries.filter((e) => e.isDirectory())) {


### PR DESCRIPTION
## Summary
- use the error log level when dynamic imports of commands or events fail

## Testing
- npm test *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c96ae9d324832d9b83bb86ba2589b5