### PR TITLE
Allow event loader base directory override

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 ### Zweck: Einstiegspunkt – erstellt den Client, lädt Commands/Events und loggt den Bot ein.
 */
 import { Client, GatewayIntentBits } from 'discord.js';
+import path from 'node:path';
 import commandLoader from './loaders/commandLoader.js';
 import eventLoader from './loaders/eventLoader.js';
 import { logger } from './util/logger.js';
@@ -39,6 +40,9 @@ process.on('uncaughtException', (err) => {
 
 logger.info('[start] Starte…');
 await commandLoader(client);
-await eventLoader(client);
+const eventsDir = process.env.EVENTS_DIR
+  ? path.resolve(process.cwd(), process.env.EVENTS_DIR)
+  : undefined;
+await eventLoader(client, eventsDir);
 
 await client.login(process.env.TOKEN);

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -5,8 +5,10 @@ import { readdir } from 'node:fs/promises';
 import path from 'node:path';
 import { logger } from '../util/logger.js';
 
-export default async function eventLoader(client) {
-  const baseDir = path.join(process.cwd(), 'src', 'events');
+export default async function eventLoader(
+  client,
+  baseDir = path.join(process.cwd(), 'src', 'events'),
+) {
   let loaded = 0;
 
   async function traverse(dir) {

--- a/src/loaders/eventLoader.test.js
+++ b/src/loaders/eventLoader.test.js
@@ -14,23 +14,22 @@ const failingEventModule = `export default {
 describe('eventLoader', () => {
   it('logs errors thrown by event handlers', async () => {
     const tempBase = await mkdtemp(path.join(tmpdir(), 'event-loader-'));
-    const eventsDir = path.join(tempBase, 'src', 'events', 'failing');
-    await mkdir(eventsDir, { recursive: true });
-    const handlerPath = path.join(eventsDir, 'handler.js');
+    const baseDir = path.join(tempBase, 'src', 'events');
+    const failingDir = path.join(baseDir, 'failing');
+    await mkdir(failingDir, { recursive: true });
+    const handlerPath = path.join(failingDir, 'handler.js');
     await writeFile(handlerPath, failingEventModule);
 
     const client = { on: vi.fn(), once: vi.fn() };
     let errorSpy;
-    let cwdSpy;
 
     try {
       vi.resetModules();
-      cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempBase);
       const { logger } = await import('../util/logger.js');
       errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
 
       const { default: eventLoader } = await import('./eventLoader.js');
-      await eventLoader(client);
+      await eventLoader(client, baseDir);
 
       expect(client.on).toHaveBeenCalledTimes(1);
       const [eventName, handler] = client.on.mock.calls[0];
@@ -43,7 +42,6 @@ describe('eventLoader', () => {
     } finally {
       await rm(tempBase, { recursive: true, force: true });
       errorSpy?.mockRestore();
-      cwdSpy?.mockRestore();
       vi.restoreAllMocks();
     }
   });


### PR DESCRIPTION
## Summary
- add an optional `baseDir` parameter to `eventLoader` with the previous default path
- allow the main entry point to override the events directory via the `EVENTS_DIR` environment variable
- update the event loader test to pass a temporary events directory without stubbing `process.cwd`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c96aec9b8c832d8357529a26715693