### PR TITLE
Add Discord logging transport for bot activity

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import path from 'node:path';
 import commandLoader from './loaders/commandLoader.js';
 import eventLoader from './loaders/eventLoader.js';
 import { logger } from './util/logger.js';
+import { setupDiscordLogging } from './util/discordLogger.js';
 
 if (!process.env.TOKEN) {
   logger.error('[start] TOKEN fehlt – Start abgebrochen.');
@@ -21,6 +22,8 @@ const client = new Client({
     GatewayIntentBits.GuildVoiceStates,
   ],
 });
+
+setupDiscordLogging(client);
 
 const shutdown = (code = 0) => {
   logger.info('[beenden] Fahre herunter…');

--- a/src/loaders/eventLoader.test.js
+++ b/src/loaders/eventLoader.test.js
@@ -11,6 +11,14 @@ const failingEventModule = `export default {
   },
 };`;
 
+const onceEventModule = `export let callCount = 0;
+export default {
+  name: 'onceEvent',
+  once: true,
+  async execute() {
+    callCount += 1;
+  },
+};`;
 
 const eventModule = (name, once = false) => `export default {
   name: '${name}',

--- a/src/util/discordLogger.js
+++ b/src/util/discordLogger.js
@@ -1,0 +1,169 @@
+import { EmbedBuilder } from 'discord.js';
+import { AUTHOR_ICON } from './embeds/author.js';
+import { formatLogArgs, registerLogTransport } from './logger.js';
+
+const DEFAULT_GENERAL_CHANNEL_ID = '1416432156770566184';
+const DEFAULT_JOIN2CREATE_CHANNEL_ID = '1416432173690519562';
+
+const generalChannelId = process.env.LOG_CHANNEL_GENERAL_ID ?? DEFAULT_GENERAL_CHANNEL_ID;
+const joinToCreateChannelId = process.env.LOG_CHANNEL_JOIN2CREATE_ID ?? DEFAULT_JOIN2CREATE_CHANNEL_ID;
+
+const LEVEL_COLOURS = {
+  debug: 0x95a5a6,
+  info: 0x3498db,
+  warn: 0xf1c40f,
+  error: 0xe74c3c,
+};
+
+const JOIN_PREFIX_REGEX = /^\s*\[join2create\]\s*/i;
+const JOIN_MATCH_REGEX = /\[join2create\]/i;
+const MAX_QUEUE_SIZE = 50;
+
+const truncate = (value, max) => {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, max - 1))}…`;
+};
+
+const formatParts = (parts) => {
+  if (!parts.length) {
+    return '_Keine Details verfügbar_';
+  }
+
+  const formatted = parts.map((part) => {
+    const trimmed = part.trim();
+    if (!trimmed) {
+      return '—';
+    }
+
+    if (trimmed.includes('\n')) {
+      const truncated = truncate(trimmed, 1900);
+      return `\u0060\u0060\u0060\n${truncated}\n\u0060\u0060\u0060`;
+    }
+
+    return truncate(trimmed, 1000);
+  });
+
+  return truncate(formatted.join('\n\n'), 4000);
+};
+
+const determineContext = (args) => {
+  for (const arg of args) {
+    if (typeof arg === 'string' && JOIN_MATCH_REGEX.test(arg)) {
+      return 'join2create';
+    }
+  }
+  return 'general';
+};
+
+const stripJoinPrefix = (arg) => {
+  if (typeof arg !== 'string') {
+    return arg;
+  }
+  return arg.replace(JOIN_PREFIX_REGEX, '');
+};
+
+export function setupDiscordLogging(client) {
+  const channelCache = new Map();
+  const queue = [];
+  let ready = Boolean(client.isReady?.());
+
+  const internalLog = (level, ...args) => {
+    const method = level === 'error' ? 'error' : 'warn';
+    console[method]('[discord-logging]', ...args);
+  };
+
+  const resolveChannel = async (channelId) => {
+    if (!channelId) {
+      return null;
+    }
+
+    if (channelCache.has(channelId)) {
+      return channelCache.get(channelId);
+    }
+
+    try {
+      const channel = await client.channels.fetch(channelId);
+      if (channel?.isTextBased?.()) {
+        channelCache.set(channelId, channel);
+        return channel;
+      }
+      channelCache.set(channelId, null);
+      internalLog('warn', `Kanal ${channelId} ist nicht textbasiert – überspringe`);
+      return null;
+    } catch (err) {
+      channelCache.set(channelId, null);
+      internalLog('error', `Kanal ${channelId} konnte nicht geladen werden:`, err);
+      return null;
+    }
+  };
+
+  const deliver = async (entry) => {
+    const context = determineContext(entry.args);
+    const targetId = context === 'join2create' ? joinToCreateChannelId : generalChannelId;
+    const fallbackId = generalChannelId;
+
+    let channel = await resolveChannel(targetId);
+    if (!channel && targetId !== fallbackId) {
+      channel = await resolveChannel(fallbackId);
+    }
+    if (!channel) {
+      return;
+    }
+
+    const cleanedArgs = context === 'join2create' ? entry.args.map(stripJoinPrefix) : entry.args;
+    const description = formatParts(formatLogArgs(cleanedArgs));
+
+    const embed = new EmbedBuilder()
+      .setColor(LEVEL_COLOURS[entry.level] ?? LEVEL_COLOURS.info)
+      .setAuthor({ name: `System Logger • ${entry.level.toUpperCase()}`, iconURL: AUTHOR_ICON })
+      .setDescription(description)
+      .setTimestamp(entry.timestamp)
+      .addFields(
+        { name: 'Level', value: `\`${entry.level.toUpperCase()}\``, inline: true },
+        {
+          name: 'Kategorie',
+          value: context === 'join2create' ? 'Join2Create' : 'Allgemein',
+          inline: true,
+        },
+      )
+      .setFooter({ text: 'Automatisches Logsystem' });
+
+    await channel.send({ embeds: [embed], allowedMentions: { parse: [] } });
+  };
+
+  const flushQueue = () => {
+    if (!ready || queue.length === 0) {
+      return;
+    }
+
+    const entries = queue.splice(0, queue.length);
+    for (const entry of entries) {
+      void deliver(entry).catch((err) => internalLog('error', 'Fehler beim Senden eines Log-Eintrags:', err));
+    }
+  };
+
+  const handler = (entry) => {
+    if (!ready) {
+      queue.push(entry);
+      if (queue.length > MAX_QUEUE_SIZE) {
+        queue.shift();
+      }
+      return;
+    }
+
+    void deliver(entry).catch((err) => internalLog('error', 'Fehler beim Senden eines Log-Eintrags:', err));
+  };
+
+  const unsubscribe = registerLogTransport(handler);
+
+  if (!ready) {
+    client.once('ready', () => {
+      ready = true;
+      flushQueue();
+    });
+  }
+
+  return unsubscribe;
+}

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,17 +1,61 @@
 /*
 ### Zweck: Einfacher Logger mit LOG_LEVEL zur einheitlichen Konsolen-Ausgabe.
 */
+import { inspect } from 'node:util';
+
 const levels = ['debug', 'info', 'warn', 'error'];
 const current = process.env.LOG_LEVEL?.toLowerCase() || 'info';
 const currentIndex = levels.indexOf(current);
+const transports = new Set();
+
+const createEntry = (level, args) => ({
+  level,
+  args,
+  timestamp: new Date(),
+});
+
+const notifyTransports = (entry) => {
+  for (const transport of transports) {
+    Promise.resolve()
+      .then(() => transport(entry))
+      .catch((err) => {
+        console.error('[logger] Log transport failed:', err);
+      });
+  }
+};
+
+const formatValue = (value) => {
+  if (value instanceof Error) {
+    return value.stack ?? `${value.name}: ${value.message}`;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return inspect(value, { depth: 3, colors: false });
+};
+
 function log(level, ...args) {
   if (levels.indexOf(level) >= currentIndex) {
     console[level](...args);
+    notifyTransports(createEntry(level, args));
   }
 }
+
 export const logger = {
   debug: (...args) => log('debug', ...args),
   info: (...args) => log('info', ...args),
   warn: (...args) => log('warn', ...args),
   error: (...args) => log('error', ...args),
 };
+
+export const logLevels = levels;
+
+export const formatLogArgs = (args) => args.map(formatValue);
+
+export function registerLogTransport(handler) {
+  if (typeof handler !== 'function') {
+    throw new TypeError('Log transport must be a function');
+  }
+  transports.add(handler);
+  return () => transports.delete(handler);
+}

--- a/src/util/logger.test.js
+++ b/src/util/logger.test.js
@@ -1,6 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ORIGINAL_LEVEL = process.env.LOG_LEVEL;
 
 describe('logger', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.LOG_LEVEL = ORIGINAL_LEVEL;
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
   it('logs only above set level', async () => {
     process.env.LOG_LEVEL = 'warn';
     vi.resetModules();
@@ -19,7 +31,38 @@ describe('logger', () => {
     expect(infoSpy).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith('warn');
     expect(errorSpy).toHaveBeenCalledWith('error');
+  });
 
-    vi.restoreAllMocks();
+  it('notifies transports for emitted logs', async () => {
+    process.env.LOG_LEVEL = 'debug';
+    vi.resetModules();
+    const { logger, registerLogTransport } = await import('./logger.js');
+    const transport = vi.fn();
+    registerLogTransport(transport);
+
+    logger.info('hello', { foo: 'bar' });
+
+    await Promise.resolve();
+
+    expect(transport).toHaveBeenCalledTimes(1);
+    const entry = transport.mock.calls[0][0];
+    expect(entry.level).toBe('info');
+    expect(entry.args[0]).toBe('hello');
+    expect(entry.args[1]).toEqual({ foo: 'bar' });
+    expect(entry.timestamp).toBeInstanceOf(Date);
+  });
+
+  it('skips transports for filtered levels', async () => {
+    process.env.LOG_LEVEL = 'error';
+    vi.resetModules();
+    const { logger, registerLogTransport } = await import('./logger.js');
+    const transport = vi.fn();
+    registerLogTransport(transport);
+
+    logger.warn('should not emit');
+
+    await Promise.resolve();
+
+    expect(transport).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add pluggable logger transports and a Discord embed transport that routes bot logs and join2create activity to their channels
- hook the Discord client startup into the new transport so queued logs flush once ready and format entries consistently
- extend logger unit tests for the transport behaviour and restore the once-event fixture used by the event loader tests

## Testing
- `npx vitest run`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c98ba79118832d86ed92acc2f86852