### PR TITLE
Add structured audit embeds for Discord logger

### DIFF
--- a/src/util/discordLogger.js
+++ b/src/util/discordLogger.js
@@ -19,6 +19,7 @@ const JOIN_PREFIX_REGEX = /^\s*\[join2create\]\s*/i;
 const JOIN_MATCH_REGEX = /\[join2create\]/i;
 const AUDIT_PREFIX_REGEX = /^\s*\[audit(?::[^\]]*)?\]\s*/i;
 const AUDIT_MATCH_REGEX = /\[audit(?::[^\]]*)?\]/i;
+const AUDIT_ACTION_REGEX = /\[audit(?::([^\]]+))?\]/i;
 const MAX_QUEUE_SIZE = 50;
 
 const truncate = (value, max) => {
@@ -80,6 +81,105 @@ const stripAuditPrefix = (arg) => {
   return arg.replace(AUDIT_PREFIX_REGEX, '');
 };
 
+const FALLBACK_FIELD_VALUE = '_Nicht angegeben_';
+
+const isPlainObject = (value) =>
+  value !== null && typeof value === 'object' && (value.constructor === Object || Object.getPrototypeOf(value) === null);
+
+const normaliseId = (value) => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  return null;
+};
+
+const formatMetadataKey = (key) => {
+  const spaced = key.replace(/[_-]+/g, ' ').replace(/([a-z])([A-Z])/g, '$1 $2');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+};
+
+const buildAuditPayload = (args) => {
+  const metadataCandidate = args[args.length - 1];
+  const metadata = isPlainObject(metadataCandidate) ? metadataCandidate : null;
+
+  const formattedArgs = [];
+  let actionType = typeof metadata?.action === 'string' ? metadata.action.trim() : '';
+
+  args.forEach((arg, index) => {
+    if (metadata && index === args.length - 1) {
+      return;
+    }
+
+    if (typeof arg === 'string' && AUDIT_MATCH_REGEX.test(arg)) {
+      if (!actionType) {
+        const match = arg.match(AUDIT_ACTION_REGEX);
+        actionType = match?.[1]?.trim() ?? '';
+      }
+      const withoutPrefix = stripAuditPrefix(arg).trim();
+      if (withoutPrefix) {
+        formattedArgs.push(withoutPrefix);
+      }
+      return;
+    }
+
+    formattedArgs.push(arg);
+  });
+
+  const description = formatParts(formatLogArgs(formattedArgs));
+
+  const actorId = normaliseId(metadata?.actorId ?? metadata?.actor);
+  const targetId = normaliseId(metadata?.targetId ?? metadata?.target);
+  const channelId = normaliseId(metadata?.channelId ?? metadata?.channel);
+
+  const actionFieldValue = actionType ? `\`${truncate(actionType, 256)}\`` : FALLBACK_FIELD_VALUE;
+  const actorFieldValue = actorId ? `<@${actorId}>` : FALLBACK_FIELD_VALUE;
+  const targetFieldValue = targetId ? `<@${targetId}>` : FALLBACK_FIELD_VALUE;
+  const channelFieldValue = channelId ? `<#${channelId}>` : FALLBACK_FIELD_VALUE;
+
+  const rawReason = metadata?.reason;
+  const reasonText = typeof rawReason === 'string' ? rawReason.trim() : rawReason != null ? String(rawReason) : '';
+  const reasonFieldValue = reasonText ? truncate(reasonText, 1024) : FALLBACK_FIELD_VALUE;
+
+  const knownKeys = new Set(['actorId', 'actor', 'targetId', 'target', 'channelId', 'channel', 'reason', 'action']);
+  const additionalFields = [];
+
+  if (metadata) {
+    for (const [key, value] of Object.entries(metadata)) {
+      if (knownKeys.has(key)) {
+        continue;
+      }
+
+      if (value == null) {
+        additionalFields.push({ name: formatMetadataKey(key), value: FALLBACK_FIELD_VALUE, inline: false });
+        continue;
+      }
+
+      const [formatted] = formatLogArgs([value]);
+      const cleanedValue = formatted?.trim();
+      additionalFields.push({
+        name: formatMetadataKey(key),
+        value: cleanedValue ? truncate(cleanedValue, 1024) : FALLBACK_FIELD_VALUE,
+        inline: false,
+      });
+    }
+  }
+
+  const fields = [
+    { name: 'Aktion', value: actionFieldValue, inline: true },
+    { name: 'Auslöser', value: actorFieldValue, inline: true },
+    { name: 'Ziel', value: targetFieldValue, inline: true },
+    { name: 'Kanal', value: channelFieldValue, inline: true },
+    { name: 'Grund', value: reasonFieldValue, inline: false },
+    ...additionalFields,
+  ];
+
+  return { description, fields };
+};
+
 export function setupDiscordLogging(client) {
   const channelCache = new Map();
   const queue = [];
@@ -128,20 +228,28 @@ export function setupDiscordLogging(client) {
       return;
     }
 
-    let cleanedArgs = entry.args;
-    if (context === 'join2create') {
-      cleanedArgs = entry.args.map(stripJoinPrefix);
-    } else if (context === 'audit') {
-      cleanedArgs = entry.args.map(stripAuditPrefix);
-    }
-
-    const description = formatParts(formatLogArgs(cleanedArgs));
-
     if (context === 'general') {
+      const description = formatParts(formatLogArgs(entry.args));
       await channel.send({ content: description, allowedMentions: { parse: [] } });
       return;
     }
 
+    if (context === 'audit') {
+      const payload = buildAuditPayload(entry.args);
+      const embed = new EmbedBuilder()
+        .setColor(LEVEL_COLOURS[entry.level] ?? LEVEL_COLOURS.info)
+        .setAuthor({ name: `System Logger • ${entry.level.toUpperCase()}`, iconURL: AUTHOR_ICON })
+        .setDescription(payload.description)
+        .setTimestamp(entry.timestamp)
+        .addFields({ name: 'Level', value: `\`${entry.level.toUpperCase()}\``, inline: true }, ...payload.fields)
+        .setFooter({ text: 'Automatisches Logsystem' });
+
+      await channel.send({ embeds: [embed], allowedMentions: { parse: [] } });
+      return;
+    }
+
+    const cleanedArgs = entry.args.map(stripJoinPrefix);
+    const description = formatParts(formatLogArgs(cleanedArgs));
     const embed = new EmbedBuilder()
       .setColor(LEVEL_COLOURS[entry.level] ?? LEVEL_COLOURS.info)
       .setAuthor({ name: `System Logger • ${entry.level.toUpperCase()}`, iconURL: AUTHOR_ICON })
@@ -149,11 +257,7 @@ export function setupDiscordLogging(client) {
       .setTimestamp(entry.timestamp)
       .addFields(
         { name: 'Level', value: `\`${entry.level.toUpperCase()}\``, inline: true },
-        {
-          name: 'Kategorie',
-          value: context === 'join2create' ? 'Join2Create' : 'Audit',
-          inline: true,
-        },
+        { name: 'Kategorie', value: 'Join2Create', inline: true },
       )
       .setFooter({ text: 'Automatisches Logsystem' });
 


### PR DESCRIPTION
## Summary
- add a helper to build structured audit log embeds with mentions and fallbacks
- send dedicated audit embeds while keeping join2create and general logs unchanged
- extend logger tests to cover metadata-rich and minimal audit entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca83831e40832d92aa5538fd4171c1