### PR TITLE
Refactor logging format helpers

### DIFF
--- a/src/events/guildAuditLogEntryCreate/handler.js
+++ b/src/events/guildAuditLogEntryCreate/handler.js
@@ -4,6 +4,7 @@
 import { AuditLogEvent } from 'discord-api-types/v10';
 import { Events } from 'discord.js';
 import { logger } from '../../util/logger.js';
+import { describeDiscordEntity, formatValue, isPlainObject } from '../../util/logging/formatting.js';
 
 const WARN_ACTIONS = new Set([
   AuditLogEvent.ChannelDelete,
@@ -30,19 +31,6 @@ const WARN_ACTIONS = new Set([
   AuditLogEvent.AutoModerationQuarantineUser,
 ]);
 
-const isPlainObject = (value) =>
-  value !== null && typeof value === 'object' && (value.constructor === Object || Object.getPrototypeOf(value) === null);
-
-const truncate = (value, max = 100) => {
-  if (typeof value !== 'string') {
-    return value;
-  }
-  if (value.length <= max) {
-    return value;
-  }
-  return `${value.slice(0, Math.max(0, max - 1))}…`;
-};
-
 const toSnakeCase = (value) => {
   if (!value) {
     return 'unknown';
@@ -66,87 +54,6 @@ const toTitleCase = (value) => {
     return 'Unbekannte Aktion';
   }
   return spaced.charAt(0).toUpperCase() + spaced.slice(1);
-};
-
-const describeDiscordEntity = (entity) => {
-  if (!entity) {
-    return null;
-  }
-  if (typeof entity === 'string' || typeof entity === 'number' || typeof entity === 'bigint') {
-    return String(entity);
-  }
-  if (typeof entity === 'boolean') {
-    return entity ? 'Ja' : 'Nein';
-  }
-  if (Array.isArray(entity)) {
-    const parts = entity
-      .map((item) => describeDiscordEntity(item))
-      .filter((part) => Boolean(part));
-    return parts.length ? parts.join(', ') : null;
-  }
-  if (entity.user) {
-    const label = describeDiscordEntity(entity.user);
-    if (label) {
-      return label;
-    }
-  }
-  if (typeof entity.tag === 'string' && entity.id) {
-    return `${entity.tag} (${entity.id})`;
-  }
-  if (typeof entity.username === 'string') {
-    const disc = entity.discriminator && entity.discriminator !== '0' ? `#${entity.discriminator}` : '';
-    return `${entity.username}${disc}${entity.id ? ` (${entity.id})` : ''}`;
-  }
-  if (typeof entity.name === 'string') {
-    return `${entity.name}${entity.id ? ` (${entity.id})` : ''}`;
-  }
-  if (typeof entity.code === 'string') {
-    return `${entity.code}${entity.id ? ` (${entity.id})` : ''}`;
-  }
-  if (entity.id) {
-    return String(entity.id);
-  }
-  return null;
-};
-
-const formatValue = (value) => {
-  if (value === null) {
-    return '—';
-  }
-  if (value === undefined) {
-    return '—';
-  }
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    return trimmed ? truncate(trimmed, 120) : '—';
-  }
-  if (typeof value === 'number' || typeof value === 'bigint') {
-    return String(value);
-  }
-  if (typeof value === 'boolean') {
-    return value ? 'Ja' : 'Nein';
-  }
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-  if (Array.isArray(value)) {
-    const formatted = value.map((item) => formatValue(item)).filter((item) => item && item !== '—');
-    return formatted.length ? truncate(formatted.join(', '), 120) : '—';
-  }
-  if (typeof value === 'object') {
-    const label = describeDiscordEntity(value);
-    if (label) {
-      return truncate(label, 120);
-    }
-    if (isPlainObject(value)) {
-      try {
-        return truncate(JSON.stringify(value), 120);
-      } catch {
-        return '[Objekt]';
-      }
-    }
-  }
-  return truncate(String(value), 120);
 };
 
 const summariseChanges = (changes) => {

--- a/src/util/discordLogger.js
+++ b/src/util/discordLogger.js
@@ -1,5 +1,6 @@
 import { EmbedBuilder } from 'discord.js';
 import { AUTHOR_ICON } from './embeds/author.js';
+import { truncate, isPlainObject, formatMetadataKey } from './logging/formatting.js';
 import { formatLogArgs, registerLogTransport } from './logger.js';
 
 const DEFAULT_GENERAL_CHANNEL_ID = '1416432156770566184';
@@ -21,13 +22,6 @@ const AUDIT_PREFIX_REGEX = /^\s*\[audit(?::[^\]]*)?\]\s*/i;
 const AUDIT_MATCH_REGEX = /\[audit(?::[^\]]*)?\]/i;
 const AUDIT_ACTION_REGEX = /\[audit(?::([^\]]+))?\]/i;
 const MAX_QUEUE_SIZE = 50;
-
-const truncate = (value, max) => {
-  if (value.length <= max) {
-    return value;
-  }
-  return `${value.slice(0, Math.max(0, max - 1))}…`;
-};
 
 const formatParts = (parts) => {
   if (!parts.length) {
@@ -83,9 +77,6 @@ const stripAuditPrefix = (arg) => {
 
 const FALLBACK_FIELD_VALUE = '_Nicht angegeben_';
 
-const isPlainObject = (value) =>
-  value !== null && typeof value === 'object' && (value.constructor === Object || Object.getPrototypeOf(value) === null);
-
 const normaliseId = (value) => {
   if (typeof value === 'string') {
     const trimmed = value.trim();
@@ -95,11 +86,6 @@ const normaliseId = (value) => {
     return String(value);
   }
   return null;
-};
-
-const formatMetadataKey = (key) => {
-  const spaced = key.replace(/[_-]+/g, ' ').replace(/([a-z])([A-Z])/g, '$1 $2');
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 };
 
 const buildAuditPayload = (args) => {

--- a/src/util/logging/formatting.js
+++ b/src/util/logging/formatting.js
@@ -1,0 +1,98 @@
+export const truncate = (value, max = 100) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, max - 1))}…`;
+};
+
+export const isPlainObject = (value) =>
+  value !== null && typeof value === 'object' && (value.constructor === Object || Object.getPrototypeOf(value) === null);
+
+export const describeDiscordEntity = (entity) => {
+  if (!entity) {
+    return null;
+  }
+  if (typeof entity === 'string' || typeof entity === 'number' || typeof entity === 'bigint') {
+    return String(entity);
+  }
+  if (typeof entity === 'boolean') {
+    return entity ? 'Ja' : 'Nein';
+  }
+  if (Array.isArray(entity)) {
+    const parts = entity
+      .map((item) => describeDiscordEntity(item))
+      .filter((part) => Boolean(part));
+    return parts.length ? parts.join(', ') : null;
+  }
+  if (entity.user) {
+    const label = describeDiscordEntity(entity.user);
+    if (label) {
+      return label;
+    }
+  }
+  if (typeof entity.tag === 'string' && entity.id) {
+    return `${entity.tag} (${entity.id})`;
+  }
+  if (typeof entity.username === 'string') {
+    const disc = entity.discriminator && entity.discriminator !== '0' ? `#${entity.discriminator}` : '';
+    return `${entity.username}${disc}${entity.id ? ` (${entity.id})` : ''}`;
+  }
+  if (typeof entity.name === 'string') {
+    return `${entity.name}${entity.id ? ` (${entity.id})` : ''}`;
+  }
+  if (typeof entity.code === 'string') {
+    return `${entity.code}${entity.id ? ` (${entity.id})` : ''}`;
+  }
+  if (entity.id) {
+    return String(entity.id);
+  }
+  return null;
+};
+
+export const formatValue = (value) => {
+  if (value === null) {
+    return '—';
+  }
+  if (value === undefined) {
+    return '—';
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? truncate(trimmed, 120) : '—';
+  }
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return String(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Ja' : 'Nein';
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    const formatted = value.map((item) => formatValue(item)).filter((item) => item && item !== '—');
+    return formatted.length ? truncate(formatted.join(', '), 120) : '—';
+  }
+  if (typeof value === 'object') {
+    const label = describeDiscordEntity(value);
+    if (label) {
+      return truncate(label, 120);
+    }
+    if (isPlainObject(value)) {
+      try {
+        return truncate(JSON.stringify(value), 120);
+      } catch {
+        return '[Objekt]';
+      }
+    }
+  }
+  return truncate(String(value), 120);
+};
+
+export const formatMetadataKey = (key) => {
+  const spaced = key.replace(/[_-]+/g, ' ').replace(/([a-z])([A-Z])/g, '$1 $2');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+};

--- a/src/util/logging/formatting.test.js
+++ b/src/util/logging/formatting.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { describeDiscordEntity, formatMetadataKey, formatValue, isPlainObject, truncate } from './formatting.js';
+
+describe('logging formatting helpers', () => {
+  describe('truncate', () => {
+    it('keeps strings within limit', () => {
+      expect(truncate('hello', 10)).toBe('hello');
+    });
+
+    it('appends ellipsis for long strings', () => {
+      expect(truncate('abcdefghijkl', 5)).toBe('abcd…');
+    });
+
+    it('returns non-string values unchanged', () => {
+      expect(truncate(42, 5)).toBe(42);
+    });
+  });
+
+  describe('isPlainObject', () => {
+    it('detects plain objects', () => {
+      expect(isPlainObject({ foo: 'bar' })).toBe(true);
+    });
+
+    it('rejects arrays and class instances', () => {
+      expect(isPlainObject([1, 2, 3])).toBe(false);
+      expect(isPlainObject(new Date())).toBe(false);
+    });
+  });
+
+  describe('describeDiscordEntity', () => {
+    it('formats user like objects with discriminator', () => {
+      expect(
+        describeDiscordEntity({ username: 'Test', discriminator: '1234', id: '42' }),
+      ).toBe('Test#1234 (42)');
+    });
+
+    it('falls back to nested user property', () => {
+      expect(describeDiscordEntity({ user: { username: 'Nested', discriminator: '0' } })).toBe('Nested');
+    });
+
+    it('combines array values', () => {
+      expect(describeDiscordEntity(['foo', { name: 'Bar' }, null])).toBe('foo, Bar');
+    });
+  });
+
+  describe('formatValue', () => {
+    it('handles primitives and nullish values', () => {
+      expect(formatValue(null)).toBe('—');
+      expect(formatValue(undefined)).toBe('—');
+      expect(formatValue('  value  ')).toBe('value');
+      expect(formatValue(true)).toBe('Ja');
+      expect(formatValue(false)).toBe('Nein');
+      expect(formatValue(123n)).toBe('123');
+    });
+
+    it('formats arrays by joining formatted entries', () => {
+      expect(formatValue([' foo ', null, 'bar'])).toBe('foo, bar');
+    });
+
+    it('describes discord entities and plain objects', () => {
+      expect(formatValue({ username: 'Fancy', discriminator: '0' })).toBe('Fancy');
+      expect(formatValue({ name: 'Example', id: '55' })).toBe('Example (55)');
+      expect(formatValue({ foo: 'bar', baz: 1 })).toBe('{"foo":"bar","baz":1}');
+    });
+  });
+
+  describe('formatMetadataKey', () => {
+    it('converts snake and camel case keys into readable labels', () => {
+      expect(formatMetadataKey('actor_id')).toBe('Actor id');
+      expect(formatMetadataKey('channelId')).toBe('Channel Id');
+      expect(formatMetadataKey('extra-id')).toBe('Extra id');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract shared logging helper functions into src/util/logging/formatting.js
- update audit log handler and discord logger to consume the new shared utilities
- add focused tests covering the shared formatting helpers

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cd111ebef8832daf748e244ba32173