### PR TITLE
Refactor Discord logging configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import commandLoader from './loaders/commandLoader.js';
 import eventLoader from './loaders/eventLoader.js';
 import { logger } from './util/logger.js';
 import { setupDiscordLogging } from './util/discordLogger.js';
+import { getLogChannelIds } from './util/logging/config.js';
 
 if (!process.env.TOKEN) {
   logger.error('[start] TOKEN fehlt – Start abgebrochen.');
@@ -23,7 +24,8 @@ const client = new Client({
   ],
 });
 
-setupDiscordLogging(client);
+const logChannelIds = getLogChannelIds();
+setupDiscordLogging(client, logChannelIds);
 
 const shutdown = (code = 0) => {
   logger.info('[beenden] Fahre herunter…');

--- a/src/util/discordLogger.js
+++ b/src/util/discordLogger.js
@@ -1,13 +1,8 @@
 import { EmbedBuilder } from 'discord.js';
 import { AUTHOR_ICON } from './embeds/author.js';
 import { truncate, isPlainObject, formatMetadataKey } from './logging/formatting.js';
+import { getLogChannelIds } from './logging/config.js';
 import { formatLogArgs, registerLogTransport } from './logger.js';
-
-const DEFAULT_GENERAL_CHANNEL_ID = '1416432156770566184';
-const DEFAULT_JOIN2CREATE_CHANNEL_ID = '1416432173690519562';
-
-const generalChannelId = process.env.LOG_CHANNEL_GENERAL_ID ?? DEFAULT_GENERAL_CHANNEL_ID;
-const joinToCreateChannelId = process.env.LOG_CHANNEL_JOIN2CREATE_ID ?? DEFAULT_JOIN2CREATE_CHANNEL_ID;
 
 const LEVEL_COLOURS = {
   debug: 0x95a5a6,
@@ -166,7 +161,12 @@ const buildAuditPayload = (args) => {
   return { description, fields };
 };
 
-export function setupDiscordLogging(client) {
+export function setupDiscordLogging(client, options = {}) {
+  const fallbackChannelIds = getLogChannelIds();
+  const generalChannelId = options.generalChannelId ?? fallbackChannelIds.generalChannelId;
+  const joinToCreateChannelId =
+    options.joinToCreateChannelId ?? fallbackChannelIds.joinToCreateChannelId;
+
   const channelCache = new Map();
   const queue = [];
   let ready = Boolean(client.isReady?.());

--- a/src/util/logger.test.js
+++ b/src/util/logger.test.js
@@ -113,6 +113,11 @@ describe('setupDiscordLogging', () => {
     await new Promise((resolve) => setImmediate(resolve));
   };
 
+  const CHANNEL_IDS = Object.freeze({
+    generalChannelId: 'general-channel',
+    joinToCreateChannelId: 'join2create-channel',
+  });
+
   const createClient = (send) => {
     const channel = {
       isTextBased: () => true,
@@ -145,13 +150,14 @@ describe('setupDiscordLogging', () => {
     const { client, fetch } = createClient(send);
 
     const { setupDiscordLogging } = await import('./discordLogger.js');
-    const unsubscribe = setupDiscordLogging(client);
+    const unsubscribe = setupDiscordLogging(client, CHANNEL_IDS);
     const { logger } = await import('./logger.js');
 
     logger.info('general entry');
     await flushAsync();
 
     expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(CHANNEL_IDS.generalChannelId);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith({
       content: expect.stringContaining('general entry'),
@@ -167,7 +173,7 @@ describe('setupDiscordLogging', () => {
     const { client } = createClient(send);
 
     const { setupDiscordLogging } = await import('./discordLogger.js');
-    const unsubscribe = setupDiscordLogging(client);
+    const unsubscribe = setupDiscordLogging(client, CHANNEL_IDS);
     const { logger } = await import('./logger.js');
 
     logger.warn('[audit:message_delete] Nachricht entfernt', {
@@ -180,6 +186,7 @@ describe('setupDiscordLogging', () => {
     await flushAsync();
 
     expect(send).toHaveBeenCalledTimes(1);
+    expect(client.channels.fetch).toHaveBeenCalledWith(CHANNEL_IDS.generalChannelId);
     const payload = send.mock.calls[0][0];
     expect(payload.content).toBeUndefined();
     expect(payload.embeds).toHaveLength(1);
@@ -207,13 +214,14 @@ describe('setupDiscordLogging', () => {
     const { client } = createClient(send);
 
     const { setupDiscordLogging } = await import('./discordLogger.js');
-    const unsubscribe = setupDiscordLogging(client);
+    const unsubscribe = setupDiscordLogging(client, CHANNEL_IDS);
     const { logger } = await import('./logger.js');
 
     logger.info('[audit:role_update] Rolle angepasst');
     await flushAsync();
 
     expect(send).toHaveBeenCalledTimes(1);
+    expect(client.channels.fetch).toHaveBeenCalledWith(CHANNEL_IDS.generalChannelId);
     const payload = send.mock.calls[0][0];
     expect(payload.content).toBeUndefined();
     expect(payload.embeds).toHaveLength(1);
@@ -240,13 +248,14 @@ describe('setupDiscordLogging', () => {
     const { client } = createClient(send);
 
     const { setupDiscordLogging } = await import('./discordLogger.js');
-    const unsubscribe = setupDiscordLogging(client);
+    const unsubscribe = setupDiscordLogging(client, CHANNEL_IDS);
     const { logger } = await import('./logger.js');
 
     logger.info('[join2create] channel created');
     await flushAsync();
 
     expect(send).toHaveBeenCalledTimes(1);
+    expect(client.channels.fetch).toHaveBeenCalledWith(CHANNEL_IDS.joinToCreateChannelId);
     const payload = send.mock.calls[0][0];
     expect(payload.content).toBeUndefined();
     expect(payload.embeds).toHaveLength(1);

--- a/src/util/logging/config.js
+++ b/src/util/logging/config.js
@@ -1,0 +1,15 @@
+const DEFAULT_GENERAL_CHANNEL_ID = '1416432156770566184';
+const DEFAULT_JOIN2CREATE_CHANNEL_ID = '1416432173690519562';
+
+export const DEFAULT_LOG_CHANNEL_IDS = Object.freeze({
+  generalChannelId: DEFAULT_GENERAL_CHANNEL_ID,
+  joinToCreateChannelId: DEFAULT_JOIN2CREATE_CHANNEL_ID,
+});
+
+export function getLogChannelIds(env = process.env) {
+  return {
+    generalChannelId: env.LOG_CHANNEL_GENERAL_ID ?? DEFAULT_LOG_CHANNEL_IDS.generalChannelId,
+    joinToCreateChannelId:
+      env.LOG_CHANNEL_JOIN2CREATE_ID ?? DEFAULT_LOG_CHANNEL_IDS.joinToCreateChannelId,
+  };
+}


### PR DESCRIPTION
## Summary
- extract Discord log channel defaults into util/logging/config with `getLogChannelIds`
- allow `setupDiscordLogging` to accept explicit channel IDs and fall back to the config helper
- update callers and tests to pass channel IDs rather than relying on implicit environment state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd13ca424c832da4a2e329ec353099