### PR TITLE
Add raw log arguments to logger entries

### DIFF
--- a/src/util/discordLogger.js
+++ b/src/util/discordLogger.js
@@ -11,37 +11,12 @@ const LEVEL_COLOURS = {
   error: 0xe74c3c,
 };
 
-const JOIN_PREFIX_REGEX = /^\s*\[join2create\]\s*/i;
 const JOIN_MATCH_REGEX = /\[join2create\]/i;
-const AUDIT_PREFIX_REGEX = /^\s*\[audit(?::[^\]]*)?\]\s*/i;
 const AUDIT_MATCH_REGEX = /\[audit(?::[^\]]*)?\]/i;
 const AUDIT_ACTION_REGEX = /\[audit(?::([^\]]+))?\]/i;
 const MAX_QUEUE_SIZE = 50;
 const DISCORD_PLAIN_TEXT_LIMIT = 2000; // Discord text messages are limited to 2000 characters.
 const DISCORD_EMBED_DESCRIPTION_LIMIT = 4000; // Embed descriptions may use up to 4096 characters; we keep a safety margin.
-
-const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-const stripContextPrefix = (value, entry, fallbackRegex) => {
-  if (typeof value !== 'string') {
-    return value;
-  }
-
-  const text = entry.context?.text;
-  if (text) {
-    const pattern = new RegExp(`^\\s*${escapeRegex(text)}\\s*`, 'i');
-    const cleaned = value.replace(pattern, '');
-    if (cleaned !== value) {
-      return cleaned;
-    }
-  }
-
-  if (fallbackRegex) {
-    return value.replace(fallbackRegex, '');
-  }
-
-  return value;
-};
 
 // Default to the embed limit because most logs are delivered via embeds (Discord allows 4096 characters).
 const formatParts = (parts, maxTotalLength = DISCORD_EMBED_DESCRIPTION_LIMIT) => {
@@ -66,11 +41,22 @@ const formatParts = (parts, maxTotalLength = DISCORD_EMBED_DESCRIPTION_LIMIT) =>
   return truncate(formatted.join('\n\n'), maxTotalLength);
 };
 
+const getRawArgs = (entry) => {
+  if (Array.isArray(entry.rawArgs)) {
+    return entry.rawArgs;
+  }
+  if (Array.isArray(entry.args)) {
+    return entry.args;
+  }
+  return [];
+};
+
 const isJoin2CreateEntry = (entry) => {
   if (entry.context?.segments?.[0] === 'join2create') {
     return 'join2create';
   }
-  return entry.args.some((arg) => typeof arg === 'string' && JOIN_MATCH_REGEX.test(arg))
+  const rawArgs = getRawArgs(entry);
+  return rawArgs.some((arg) => typeof arg === 'string' && JOIN_MATCH_REGEX.test(arg))
     ? 'join2create'
     : null;
 };
@@ -79,7 +65,8 @@ const isAuditEntry = (entry) => {
   if (entry.context?.segments?.[0] === 'audit') {
     return 'audit';
   }
-  return entry.args.some((arg) => typeof arg === 'string' && AUDIT_MATCH_REGEX.test(arg)) ? 'audit' : null;
+  const rawArgs = getRawArgs(entry);
+  return rawArgs.some((arg) => typeof arg === 'string' && AUDIT_MATCH_REGEX.test(arg)) ? 'audit' : null;
 };
 
 const determineContext = (entry) => {
@@ -91,10 +78,6 @@ const determineContext = (entry) => {
   }
   return 'general';
 };
-
-const stripJoinPrefix = (arg, entry) => stripContextPrefix(arg, entry, JOIN_PREFIX_REGEX);
-
-const stripAuditPrefix = (arg, entry) => stripContextPrefix(arg, entry, AUDIT_PREFIX_REGEX);
 
 const FALLBACK_FIELD_VALUE = '_Nicht angegeben_';
 
@@ -110,7 +93,7 @@ const normaliseId = (value) => {
 };
 
 const buildAuditPayload = (entry) => {
-  const args = entry.args;
+  const args = getRawArgs(entry);
   const metadataCandidate = args[args.length - 1];
   const metadata = isPlainObject(metadataCandidate) ? metadataCandidate : null;
 
@@ -133,9 +116,12 @@ const buildAuditPayload = (entry) => {
         const match = arg.match(AUDIT_ACTION_REGEX);
         actionType = match?.[1]?.trim() ?? '';
       }
-      const withoutPrefix = stripAuditPrefix(arg, entry).trim();
-      if (withoutPrefix) {
-        formattedArgs.push(withoutPrefix);
+      const closingIndex = arg.indexOf(']');
+      if (closingIndex >= 0) {
+        const remainder = arg.slice(closingIndex + 1).trim();
+        if (remainder) {
+          formattedArgs.push(remainder);
+        }
       }
       return;
     }
@@ -249,7 +235,7 @@ export function setupDiscordLogging(client, options = {}) {
 
     if (context === 'general') {
       // Plain text messages must respect the 2000 character Discord limit.
-      const description = formatParts(formatLogArgs(entry.args), DISCORD_PLAIN_TEXT_LIMIT);
+      const description = formatParts(formatLogArgs(getRawArgs(entry)), DISCORD_PLAIN_TEXT_LIMIT);
       await channel.send({ content: description, allowedMentions: { parse: [] } });
       return;
     }
@@ -268,8 +254,7 @@ export function setupDiscordLogging(client, options = {}) {
       return;
     }
 
-    const cleanedArgs = entry.args.map((arg) => stripJoinPrefix(arg, entry));
-    const description = formatParts(formatLogArgs(cleanedArgs));
+    const description = formatParts(formatLogArgs(getRawArgs(entry)));
     const embed = new EmbedBuilder()
       .setColor(LEVEL_COLOURS[entry.level] ?? LEVEL_COLOURS.info)
       .setAuthor({ name: `System Logger • ${entry.level.toUpperCase()}`, iconURL: AUTHOR_ICON })

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -26,9 +26,10 @@ const buildContextPayload = (context) => {
   };
 };
 
-const createEntry = (level, args, context) => ({
+const createEntry = (level, args, rawArgs, context) => ({
   level,
   args,
+  rawArgs,
   timestamp: new Date(),
   context: buildContextPayload(context),
 });
@@ -99,7 +100,7 @@ const createLoggerInstance = (context) => {
 
     const argsWithPrefix = applyPrefix(context.segments, args);
     console[level](...argsWithPrefix);
-    notifyTransports(createEntry(level, argsWithPrefix, context));
+    notifyTransports(createEntry(level, argsWithPrefix, args, context));
   };
 
   const withPrefix = (prefix, metadata) => {

--- a/src/util/logger.test.js
+++ b/src/util/logger.test.js
@@ -89,6 +89,8 @@ describe('logger', () => {
     expect(entry.level).toBe('info');
     expect(entry.args[0]).toBe('hello');
     expect(entry.args[1]).toEqual({ foo: 'bar' });
+    expect(entry.rawArgs[0]).toBe('hello');
+    expect(entry.rawArgs[1]).toEqual({ foo: 'bar' });
     expect(entry.timestamp).toBeInstanceOf(Date);
   });
 
@@ -110,6 +112,8 @@ describe('logger', () => {
     expect(transport).toHaveBeenCalledTimes(1);
     const entry = transport.mock.calls[0][0];
     expect(entry.args[0]).toBe('[test] message');
+    expect(entry.rawArgs[0]).toBe('message');
+    expect(entry.rawArgs[1]).toEqual({ foo: 'bar' });
     expect(entry.context).toMatchObject({
       label: 'test',
       segments: ['test'],
@@ -246,7 +250,7 @@ describe('setupDiscordLogging', () => {
     expect(payload.content).toBeUndefined();
     expect(payload.embeds).toHaveLength(1);
     const embed = payload.embeds[0];
-    expect(embed.data.description).toContain('Nachricht entfernt');
+    expect(embed.data.description).toBe('Nachricht entfernt');
     expect(embed.data.description).not.toMatch(/\[audit/i);
 
     expect(embed.data.fields).toEqual(
@@ -282,7 +286,7 @@ describe('setupDiscordLogging', () => {
     expect(payload.content).toBeUndefined();
     expect(payload.embeds).toHaveLength(1);
     const embed = payload.embeds[0];
-    expect(embed.data.description).toContain('Rolle angepasst');
+    expect(embed.data.description).toBe('Rolle angepasst');
     expect(embed.data.description).not.toMatch(/\[audit/i);
 
     expect(embed.data.fields).toEqual(
@@ -317,7 +321,7 @@ describe('setupDiscordLogging', () => {
     expect(payload.content).toBeUndefined();
     expect(payload.embeds).toHaveLength(1);
     const embed = payload.embeds[0];
-    expect(embed.data.description).toContain('channel created');
+    expect(embed.data.description).toBe('channel created');
     expect(embed.data.description).not.toMatch(/\[join2create/i);
     expect(embed.data.fields).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
## Summary
- extend log entries with `rawArgs` so transports receive unmodified arguments alongside console-formatted ones
- refactor the Discord log transport to rely on `rawArgs` for context detection and embed/plain-text descriptions, allowing the regex prefix stripping helpers to be removed
- update the logger and Discord logging tests to cover the new field and the simplified prefix handling

## Testing
- `npm test` *(fails: vitest CLI is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdae7e8ba0832da5a02bf7fc880f6b