### PR TITLE
Align teamlist fallback titles with embed builder

### DIFF
--- a/src/modules/teamlist/embed.js
+++ b/src/modules/teamlist/embed.js
@@ -19,6 +19,11 @@ import { logger } from '../../util/logger.js';
 
 const teamLogger = logger.withPrefix('team');
 
+export const TEAM_TITLES = {
+  en: 'The Server Team',
+  de: 'Das Serverteam',
+};
+
 async function getRoleMemberMentions(guild, roleId) {
   // Cache auffüllen, falls nötig
   if (guild.members.cache.size < guild.memberCount) {
@@ -41,8 +46,7 @@ async function getRoleMemberMentions(guild, roleId) {
 
 export async function buildTeamEmbedAndComponents(lang = 'en', guild) {
   const isDe = lang === 'de';
-
-  const title = isDe ? 'Das Serverteam' : 'The Server Team';
+  const title = isDe ? TEAM_TITLES.de : TEAM_TITLES.en;
 
   // Beschreibungen: beide Varianten als Quote ("> ") und kursiv (*...*)
   const description = isDe

--- a/src/modules/teamlist/ensure.js
+++ b/src/modules/teamlist/ensure.js
@@ -2,10 +2,15 @@
 ### Zweck: Stellt sicher, dass genau eine Teamlisten-Nachricht existiert.
 */
 import { TEAM_CHANNEL_ID, TEAM_MESSAGE_ID, TEAM_BUTTON_ID_EN, TEAM_BUTTON_ID_DE, TEAM_ROLES } from './config.js';
-import { buildTeamEmbedAndComponents } from './embed.js';
+import { buildTeamEmbedAndComponents, TEAM_TITLES } from './embed.js';
 import { logger } from '../../util/logger.js';
 
 const teamLogger = logger.withPrefix('team');
+const FALLBACK_EMBED_TITLES = new Set([
+  ...Object.values(TEAM_TITLES),
+  '💠 The Server Team 💠',
+  '💠 Das Serverteam 💠',
+]);
 
 export async function ensureTeamMessage(client) {
   let channel;
@@ -44,7 +49,7 @@ export async function ensureTeamMessage(client) {
     const messages = await channel.messages.fetch({ limit: 10 });
     message = messages.find((m) =>
       m.author?.id === client.user?.id &&
-      (m.embeds.some((e) => e.title === '💠 The Server Team 💠' || e.title === '💠 Das Serverteam 💠') ||
+      (m.embeds.some((e) => e?.title && FALLBACK_EMBED_TITLES.has(e.title)) ||
         m.components.some((row) =>
           row.components.some((c) => c.customId === TEAM_BUTTON_ID_EN || c.customId === TEAM_BUTTON_ID_DE)
         ))


### PR DESCRIPTION
## Summary
- expose the current team embed titles from the builder for reuse
- reuse the shared titles in ensureTeamMessage's fallback detection while keeping the button check for safety

## Testing
- npm run lint *(fails: Parsing error in src/util/discordLogger.js)*
- TOKEN=dummy node src/index.js *(fails: SyntaxError in src/util/discordLogger.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cec6327ea4832d9d75279417d8e4a3