### PR TITLE
Simplify audit log embed content

### DIFF
--- a/src/events/guildAuditLogEntryCreate/handler.test.js
+++ b/src/events/guildAuditLogEntryCreate/handler.test.js
@@ -57,17 +57,17 @@ describe('guildAuditLogEntryCreate handler', () => {
     expect(infoSpy).not.toHaveBeenCalled();
     const [message, metadata] = warnSpy.mock.calls[0];
     expect(message).toBe(
-      '[audit:message_delete] Aktion Message Delete (Delete) • Ziel [User]: User#1234 (222) • Änderungen: count: 2 • Details: Kanal: allgemein (333); Anzahl: 2',
+      '[audit:message_delete] Message Delete: User#1234 (222) • Kanal: <#333>, Anzahl: 2 • Änderungen: Count',
     );
     expect(metadata).toContain("action: 'message_delete'");
     expect(metadata).toContain("actorId: '1111'");
-    expect(metadata).toContain("channelId: '333'");
-    expect(metadata).toContain("count: 2");
-    expect(metadata).toContain("entryId: 'audit-123'");
-    expect(metadata).toContain("guildId: '999'");
-    expect(metadata).toContain("reason: 'Spam'");
     expect(metadata).toContain("targetId: '222'");
-    expect(metadata).toContain("targetType: 'User'");
+    expect(metadata).toContain("targetMention: '<@222>'");
+    expect(metadata).toContain("reason: 'Spam'");
+    expect(metadata).not.toContain('entryId');
+    expect(metadata).not.toContain('guildId');
+    expect(metadata).not.toContain('targetType');
+    expect(metadata).not.toContain('channelId');
 
     warnSpy.mockRestore();
     infoSpy.mockRestore();
@@ -93,15 +93,16 @@ describe('guildAuditLogEntryCreate handler', () => {
     expect(warnSpy).not.toHaveBeenCalled();
     const [message, metadata] = infoSpy.mock.calls[0];
     expect(message).toBe(
-      '[audit:role_update] Aktion Role Update (Update) • Ziel [Role]: Example Rolle (2222) • Änderungen: name: Alte Rolle → Neue Rolle; permissions: {"allow":"8"}',
+      '[audit:role_update] Role Update: Example Rolle (2222) • Änderungen: Name, Permissions',
     );
     expect(metadata).toContain("action: 'role_update'");
     expect(metadata).toContain("actorId: '1111'");
-    expect(metadata).toContain("entryId: 'log-entry-1'");
-    expect(metadata).toContain("guildId: '999'");
-    expect(metadata).toContain("reason: 'Routine-Anpassung'");
     expect(metadata).toContain("targetId: '2222'");
-    expect(metadata).toContain("targetType: 'Role'");
+    expect(metadata).toContain("targetMention: '<@&2222>'");
+    expect(metadata).toContain("reason: 'Routine-Anpassung'");
+    expect(metadata).not.toContain('entryId');
+    expect(metadata).not.toContain('guildId');
+    expect(metadata).not.toContain('targetType');
 
     warnSpy.mockRestore();
     infoSpy.mockRestore();

--- a/src/util/logger.test.js
+++ b/src/util/logger.test.js
@@ -313,14 +313,15 @@ describe('setupDiscordLogging', () => {
     expect(embed.data.fields).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: 'Level', value: '`WARN`' }),
+        expect.objectContaining({ name: 'Kategorie', value: 'Audit' }),
         expect.objectContaining({ name: 'Aktion', value: '`message_delete`' }),
         expect.objectContaining({ name: 'Auslöser', value: '<@111>' }),
         expect.objectContaining({ name: 'Ziel', value: '<@222>' }),
-        expect.objectContaining({ name: 'Kanal', value: '<#333>' }),
         expect.objectContaining({ name: 'Grund', value: 'Spam' }),
-        expect.objectContaining({ name: 'Count', value: '2' }),
       ]),
     );
+    expect(embed.data.fields.some((field) => field.name === 'Kanal')).toBe(false);
+    expect(embed.data.fields.some((field) => field.name === 'Count')).toBe(false);
 
     unsubscribe();
   });
@@ -376,13 +377,13 @@ describe('setupDiscordLogging', () => {
     expect(embed.data.fields).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: 'Level', value: '`INFO`' }),
+        expect.objectContaining({ name: 'Kategorie', value: 'Audit' }),
         expect.objectContaining({ name: 'Aktion', value: '`role_update`' }),
         expect.objectContaining({ name: 'Auslöser', value: '_Nicht angegeben_' }),
         expect.objectContaining({ name: 'Ziel', value: '_Nicht angegeben_' }),
-        expect.objectContaining({ name: 'Kanal', value: '_Nicht angegeben_' }),
-        expect.objectContaining({ name: 'Grund', value: '_Nicht angegeben_' }),
       ]),
     );
+    expect(embed.data.fields.some((field) => field.name === 'Grund')).toBe(false);
 
     unsubscribe();
   });


### PR DESCRIPTION
## Summary
- trim guild audit log metadata to the essentials when emitting entries
- simplify audit log embed fields to action, trigger, target, and optional reason
- update audit logging tests to reflect the compact embed payloads

## Testing
- npx vitest run src/events/guildAuditLogEntryCreate/handler.test.js
- npx vitest run src/util/logger.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cfe8ede2e0832db900ff98e7a880d0