### PR TITLE
Prevent verify embeds from pinging roles

### DIFF
--- a/src/modules/verify/ensure.js
+++ b/src/modules/verify/ensure.js
@@ -20,7 +20,10 @@ export default async function ensureVerifyMessage(client) {
     return;
   }
 
-  const payload = buildVerifyEmbedAndComponents(VERIFY_DEFAULT_LANG);
+  const payload = {
+    ...buildVerifyEmbedAndComponents(VERIFY_DEFAULT_LANG),
+    allowedMentions: { parse: [] },
+  };
   let message = null;
 
   if (VERIFY_MESSAGE_ID) {

--- a/src/modules/verify/interactions.js
+++ b/src/modules/verify/interactions.js
@@ -81,7 +81,10 @@ export async function handleVerifyInteractions(interaction, client) {
   ) {
     const lang = interaction.customId === VERIFY_LANG_DE_ID ? 'de' : 'en';
     try {
-      await interaction.update(buildVerifyEmbedAndComponents(lang));
+      await interaction.update({
+        ...buildVerifyEmbedAndComponents(lang),
+        allowedMentions: { parse: [] },
+      });
       verifyLogger.info(`Sprache → ${lang.toUpperCase()}`);
     } catch (err) {
       verifyLogger.error('Fehler beim Umschalten der Sprache:', err);
@@ -94,7 +97,10 @@ export async function handleVerifyInteractions(interaction, client) {
     }
     const timeout = setTimeout(async () => {
       try {
-        await interaction.message.edit(buildVerifyEmbedAndComponents('en'));
+        await interaction.message.edit({
+          ...buildVerifyEmbedAndComponents('en'),
+          allowedMentions: { parse: [] },
+        });
         verifyLogger.info('Sprache → EN (Timeout)');
       } catch (err) {
         verifyLogger.error('Fehler beim Zurücksetzen der Sprache:', err);


### PR DESCRIPTION
## Summary
- add allowed mentions suppression when updating verify interaction responses
- ensure verify message creation and updates include an empty allowed mention set

## Testing
- npm run lint
- not run: manual verification of buttons with a Discord account

------
https://chatgpt.com/codex/tasks/task_e_68d55fa296b0832daa6939a087f11c8f