### PR TITLE
Update welcome embed language

### DIFF
--- a/src/events/guildMemberAdd/handler.js
+++ b/src/events/guildMemberAdd/handler.js
@@ -21,13 +21,13 @@ export default {
     const channel = member.guild?.channels.cache.get(WELCOME_CHANNEL_ID);
     if (!channel) return;
 
-    const description = `> Hello ${member}, welcome to **The Core**.\n\n> Bitte lies dir die Regeln im Channel <#${RULES_CHANNEL_ID}> durch!`;
+    const description = `> Hello ${member}, welcome to **The Core**.\n\n> Please read the rules in channel <#${RULES_CHANNEL_ID}>!`;
 
     const embed = new EmbedBuilder()
       .setColor(COLOR)
       .setTitle('Welcome!')
       .setDescription(description)
-      .setAuthor({ name: 'The Core', iconURL: AUTHOR_ICON })
+      .setAuthor({ name: 'The Core Welcome/Willkommen', iconURL: AUTHOR_ICON })
       .setFooter(FOOTER)
       .setThumbnail(WELCOME_IMAGE_URL);
 


### PR DESCRIPTION
## Summary
- translate the rules reminder in the welcome embed to English so the entire message is consistent
- append "Welcome/Willkommen" to the author label to match the desired display

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d55fdbf020832d8d925b7d89102e17