### PR TITLE
Adjust join2create voice permissions

### DIFF
--- a/src/events/voiceStateUpdate/handler.js
+++ b/src/events/voiceStateUpdate/handler.js
@@ -19,6 +19,14 @@ export default {
         });
         await channel.permissionOverwrites.edit(member, {
           ManageChannels: true,
+          Connect: true,
+          Speak: true,
+          UseVAD: true,
+        });
+        await channel.permissionOverwrites.edit('1354909911691038862', {
+          Connect: true,
+          Speak: true,
+          UseVAD: true,
         });
         createdChannels.add(channel.id);
         await newState.setChannel(channel);


### PR DESCRIPTION
## Summary
- ensure join-to-create channels grant the creator manage and voice permissions
- allow role 1354909911691038862 to connect, speak, and use VAD in created voice channels

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d575992ce4832db38aa9962aff3a33