### PR TITLE
Centralize welcome embed author configuration

### DIFF
--- a/src/events/guildMemberAdd/handler.js
+++ b/src/events/guildMemberAdd/handler.js
@@ -4,7 +4,7 @@
 import { Events, EmbedBuilder } from 'discord.js';
 import { COLOR } from '../../util/embeds/color.js';
 import { FOOTER } from '../../util/embeds/footer.js';
-import { AUTHOR_ICON } from '../../util/embeds/author.js';
+import { applyAuthor } from '../../util/embeds/author.js';
 import { logger } from '../../util/logger.js';
 import {
   WELCOME_CHANNEL_ID,
@@ -23,11 +23,10 @@ export default {
 
     const description = `> Hello ${member}, welcome to **The Core**.\n\n> Please read the rules in channel <#${RULES_CHANNEL_ID}>!`;
 
-    const embed = new EmbedBuilder()
+    const embed = applyAuthor(new EmbedBuilder(), 'WELCOME')
       .setColor(COLOR)
       .setTitle('Welcome!')
       .setDescription(description)
-      .setAuthor({ name: 'The Core Welcome/Willkommen', iconURL: AUTHOR_ICON })
       .setFooter(FOOTER)
       .setThumbnail(WELCOME_IMAGE_URL);
 

--- a/src/util/embeds/author.js
+++ b/src/util/embeds/author.js
@@ -7,6 +7,9 @@ export const AUTHORS = {
     en: "The Core - Ticket System",
     de: "The Core - Ticket System",
   },
+  WELCOME: {
+    en: "The Core Welcome/Willkommen",
+  },
   VERIFY: {
     en: "The Core - Verify System",
     de: "The Core - Verify System",
@@ -34,7 +37,7 @@ export const AUTHORS = {
  * und gewählter Sprache ('en' oder 'de'). Fällt auf 'en' oder 'The Core' zurück, wenn nichts gefunden wird.
  *
  * @param {EmbedBuilder} embed
- * @param {"VERIFY"|"RULES"|"TEAM"|"ANN"|"LOGS"} context
+ * @param {"VERIFY"|"RULES"|"TEAM"|"ANN"|"LOGS"|"WELCOME"} context
  * @param {"en"|"de"} lang
  * @returns {EmbedBuilder}
  */
@@ -49,7 +52,7 @@ export function applyAuthorByLang(embed, context, lang = "en") {
  * Verwendet standardmäßig die englische Variante.
  *
  * @param {EmbedBuilder} embed
- * @param {"TICKET"|"VERIFY"|"RULES"|"TEAM"|"ANN"} context
+ * @param {"TICKET"|"VERIFY"|"RULES"|"TEAM"|"ANN"|"WELCOME"} context
  * @returns {EmbedBuilder}
  */
 export function applyAuthor(embed, context) {


### PR DESCRIPTION
## Summary
- add a welcome author entry to the shared embed author registry
- update the welcome embed handler to reuse the central author helper for consistent styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d57a68ad80832d9eafeb99bdb578eb