### PR TITLE
Unify embed styling via core embed factory

### DIFF
--- a/src/commands/clear/command.js
+++ b/src/commands/clear/command.js
@@ -1,4 +1,6 @@
-import { EmbedBuilder, ApplicationCommandOptionType } from 'discord.js';
+import { ApplicationCommandOptionType } from 'discord.js';
+import { coreEmbed } from '../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../util/embeds/lang.js';
 
 const ROLE_ID = '1363298860121985215';
 
@@ -16,9 +18,10 @@ export default {
   ],
   async execute(interaction) {
     const amount = interaction.options.getInteger('amount', true);
+    const lang = detectLangFromInteraction(interaction);
 
     if (!interaction.member.roles.cache.has(ROLE_ID)) {
-      const embed = new EmbedBuilder()
+      const embed = coreEmbed('ANN', lang)
         .setTitle('No Permission')
         .setDescription('You do not have permission to use this command.')
         .setColor(0xff0000);
@@ -36,7 +39,7 @@ export default {
       deleted = 0;
     }
 
-    const embed = new EmbedBuilder()
+    const embed = coreEmbed('ANN', lang)
       .setTitle('Messages Cleared')
       .setDescription(`Deleted **${deleted}** messages in <#${interaction.channel.id}>.`)
       .setColor(0x00ff00);

--- a/src/commands/ping/command.js
+++ b/src/commands/ping/command.js
@@ -1,8 +1,8 @@
 /*
 ### Zweck: Slash-Command /ping – zeigt Ping, Roundtrip, Uptime und Serverzeit als Embed.
 */
-import { EmbedBuilder } from 'discord.js';
-import { FOOTER } from '../../util/embeds/footer.js';
+import { coreEmbed } from '../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../util/embeds/lang.js';
 
 export default {
   name: 'ping',
@@ -15,7 +15,7 @@ export default {
     const uptimeMs = client.uptime ?? 0;
     const uptime = formatDuration(uptimeMs);
 
-    const embed = new EmbedBuilder()
+    const embed = coreEmbed('ANN', detectLangFromInteraction(interaction))
       .setTitle('🟢 The Core System — Status')
       .setDescription('✅ Operational.')
       .addFields(
@@ -23,9 +23,7 @@ export default {
         { name: '⏱️ Roundtrip', value: `${roundtrip} ms`, inline: true },
         { name: '⏳ Uptime', value: uptime, inline: true },
         { name: '🕒 Server Time', value: new Date().toISOString(), inline: false }
-      )
-      .setColor(0xFFD700)
-      .setFooter(FOOTER);
+      );
 
     await interaction.editReply({ embeds: [embed] });
   },

--- a/src/events/guildMemberAdd/handler.js
+++ b/src/events/guildMemberAdd/handler.js
@@ -1,10 +1,9 @@
 /*
 ### Zweck: Reagiert auf neue Mitglieder und sendet eine Willkommensnachricht.
 */
-import { Events, EmbedBuilder } from 'discord.js';
-import { COLOR } from '../../util/embeds/color.js';
-import { FOOTER } from '../../util/embeds/footer.js';
-import { AUTHOR_ICON } from '../../util/embeds/author.js';
+import { Events } from 'discord.js';
+import { coreEmbed } from '../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../util/embeds/lang.js';
 import { logger } from '../../util/logging/logger.js';
 import {
   WELCOME_CHANNEL_ID,
@@ -23,12 +22,11 @@ export default {
 
     const description = `> Hello ${member}, welcome to **The Core**.\n\n> Please read the rules in channel <#${RULES_CHANNEL_ID}>!`;
 
-    const embed = new EmbedBuilder()
-      .setColor(COLOR)
+    const lang = detectLangFromInteraction(member);
+
+    const embed = coreEmbed('WELCOME', lang)
       .setTitle('Welcome!')
       .setDescription(description)
-      .setAuthor({ name: 'The Core Welcome/Willkommen', iconURL: AUTHOR_ICON })
-      .setFooter(FOOTER)
       .setThumbnail(WELCOME_IMAGE_URL);
 
     try {

--- a/src/modules/rules/embed.js
+++ b/src/modules/rules/embed.js
@@ -1,15 +1,8 @@
 /*
 ### Zweck: Baut die Rules-Embed und die Sprachwahl-Buttons.
 */
-import {
-  EmbedBuilder,
-  ButtonBuilder,
-  ActionRowBuilder,
-  ButtonStyle,
-} from "discord.js";
-import { FOOTER } from "../../util/embeds/footer.js";
-import { applyAuthorByLang } from "../../util/embeds/author.js";
-import { COLOR } from "../../util/embeds/color.js";
+import { ButtonBuilder, ActionRowBuilder, ButtonStyle } from "discord.js";
+import { coreEmbed } from "../../util/embeds/core.js";
 import { RULES_BUTTON_ID_EN, RULES_BUTTON_ID_DE } from "./config.js";
 
 const FIELDS_EN = [
@@ -125,13 +118,10 @@ export function buildRulesEmbedAndComponents(lang = "en") {
     ? "🛡️ *Offizielle Server-Regeln von **The Core Team** — alle müssen sich daran halten.*"
     : "🛡️ *Official server rules by **The Core Team** — everyone must follow them.*";
 
-  const embed = new EmbedBuilder()
-    .setColor(COLOR)
+  const embed = coreEmbed("RULES", lang)
     .setTitle(title)
     .setDescription(description)
-    .setFields(fields)
-    .setFooter(FOOTER);
-  applyAuthorByLang(embed, "RULES", lang);
+    .setFields(fields);
 
   const enButton = new ButtonBuilder()
     .setCustomId(RULES_BUTTON_ID_EN)

--- a/src/modules/teamlist/embed.js
+++ b/src/modules/teamlist/embed.js
@@ -1,15 +1,8 @@
 /*
 ### Zweck: Baut die Teamlisten-Embed und Sprach-Buttons.
 */
-import {
-  EmbedBuilder,
-  ButtonBuilder,
-  ActionRowBuilder,
-  ButtonStyle,
-} from 'discord.js';
-import { FOOTER } from '../../util/embeds/footer.js';
-import { applyAuthorByLang } from '../../util/embeds/author.js';
-import { COLOR } from '../../util/embeds/color.js';
+import { ButtonBuilder, ActionRowBuilder, ButtonStyle } from 'discord.js';
+import { coreEmbed } from '../../util/embeds/core.js';
 import {
   TEAM_BUTTON_ID_EN,
   TEAM_BUTTON_ID_DE,
@@ -53,12 +46,9 @@ export async function buildTeamEmbedAndComponents(lang = 'en', guild) {
     ? '> *Sehr geehrte Community, hier findet ihr unsere Teamliste. Hier könnt ihr sehen, wer zum Serverteam gehört. Dies hilft, um immer zu wissen, ob man den Personen trauen kann.*'
     : '> *Dear community, here you can find our team list. Here you can see who is part of the server team. This helps you always know whom you can trust.*';
 
-  const embed = new EmbedBuilder()
-    .setColor(COLOR)
+  const embed = coreEmbed('TEAM', lang)
     .setTitle(title)
-    .setDescription(description)
-    .setFooter(FOOTER);
-  applyAuthorByLang(embed, 'TEAM', lang);
+    .setDescription(description);
 
   // Nur Rollen rendern, die mindestens 1 Mitglied haben
   for (const role of TEAM_ROLES) {

--- a/src/modules/tickets/interactions.js
+++ b/src/modules/tickets/interactions.js
@@ -12,19 +12,20 @@ import {
 } from './config.js';
 import { openTicket } from './open.js';
 import { isTeam, setStatusPrefix } from './utils.js';
-import { FOOTER } from '../../util/embeds/footer.js';
-import { applyAuthor } from '../../util/embeds/author.js';
+import { coreEmbed } from '../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../util/embeds/lang.js';
 import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
-  EmbedBuilder,
 } from 'discord.js';
 import { logger } from '../../util/logging/logger.js';
 
 const ticketLogger = logger.withPrefix('tickets');
 
 export async function handleTicketInteractions(interaction, client) {
+  const lang = detectLangFromInteraction(interaction);
+
   if (interaction.isStringSelectMenu() && interaction.customId === MENU_CUSTOM_ID) {
     const value = interaction.values?.[0];
     if (value === 'support_en') {
@@ -40,7 +41,7 @@ export async function handleTicketInteractions(interaction, client) {
   switch (interaction.customId) {
     case BTN_CLAIM_ID: {
       if (!isTeam(interaction.member)) {
-        const embed = new EmbedBuilder()
+        const embed = coreEmbed('TICKET', lang)
           .setTitle('No Permission')
           .setDescription('You do not have permission to claim this ticket.')
           .setColor(0xff0000);
@@ -49,7 +50,7 @@ export async function handleTicketInteractions(interaction, client) {
       }
       await interaction.deferUpdate();
       await setStatusPrefix(interaction.channel, 'claimed');
-      const info = applyAuthor(new EmbedBuilder(), 'TICKET')
+      const info = coreEmbed('TICKET', lang)
         .setColor(0x57f287)
         .setDescription(
           `🇺🇸 **Claimed** by <@${interaction.user.id}>\n\n🇩🇪 **Beansprucht** von <@${interaction.user.id}>`
@@ -67,7 +68,7 @@ export async function handleTicketInteractions(interaction, client) {
         .setEmoji('✅')
         .setStyle(ButtonStyle.Primary);
       const row = new ActionRowBuilder().addComponents(btn);
-      const embed = new EmbedBuilder().setDescription(
+      const embed = coreEmbed('TICKET', lang).setDescription(
         '🇺🇸 **Are you sure** you want to close this ticket?\n\n🇩🇪 **Bist du sicher**, dass du dieses Ticket schließen möchtest?'
       );
       await interaction.reply({ embeds: [embed], components: [row], ephemeral: true, allowedMentions: { parse: [] } });
@@ -109,7 +110,7 @@ export async function handleTicketInteractions(interaction, client) {
         await startMsg.edit({ components: [row], embeds: startMsg.embeds, allowedMentions: { parse: [] } });
       }
       await setStatusPrefix(interaction.channel, 'closed');
-      const embed = new EmbedBuilder().setDescription(
+      const embed = coreEmbed('TICKET', lang).setDescription(
         '🇺🇸 **Ticket archived**\n\n🇩🇪 **Ticket archiviert**'
       );
       await interaction.update({ embeds: [embed], components: [], allowedMentions: { parse: [] } });
@@ -166,11 +167,10 @@ export async function handleTicketInteractions(interaction, client) {
         const row = new ActionRowBuilder().addComponents(claimBtn, closeBtn);
         await startMsg.edit({ components: [row], embeds: startMsg.embeds, allowedMentions: { parse: [] } });
       }
-      const info = applyAuthor(new EmbedBuilder(), 'TICKET')
+      const info = coreEmbed('TICKET', lang)
         .setDescription(
           '🔓 Ticket reopened | 🔓 Ticket wieder eröffnet\n• Please describe your issue. | Bitte beschreibe dein Anliegen.'
-        )
-        .setFooter(FOOTER);
+        );
       await interaction.channel.send({ embeds: [info], allowedMentions: { parse: [] } });
       await interaction.update({
         content: 'Reopened | Wieder eröffnet',
@@ -186,7 +186,7 @@ export async function handleTicketInteractions(interaction, client) {
         .setEmoji('✅')
         .setStyle(ButtonStyle.Danger);
       const row = new ActionRowBuilder().addComponents(btn);
-      const embed = new EmbedBuilder().setDescription(
+      const embed = coreEmbed('TICKET', lang).setDescription(
         '🇺🇸 **Are you sure** you want to delete this ticket?\n\n🇩🇪 **Bist du sicher**, dass du dieses Ticket löschen möchtest?'
       );
       await interaction.reply({
@@ -198,7 +198,7 @@ export async function handleTicketInteractions(interaction, client) {
       return;
     }
     case BTN_DELETE_CONFIRM_ID: {
-      const embed = new EmbedBuilder().setDescription(
+      const embed = coreEmbed('TICKET', lang).setDescription(
         '🇺🇸 **Deleting in 5 seconds…**\n\n🇩🇪 **Löschen in 5 Sekunden…**'
       );
       await interaction.update({ embeds: [embed], components: [], allowedMentions: { parse: [] } });

--- a/src/modules/tickets/open.js
+++ b/src/modules/tickets/open.js
@@ -6,15 +6,12 @@ import {
   TICKET_CHANNEL_PREFIX,
 } from './config.js';
 import { buildTicketName } from './utils.js';
-import { FOOTER } from '../../util/embeds/footer.js';
-import { applyAuthor } from '../../util/embeds/author.js';
-import { COLOR } from '../../util/embeds/color.js';
+import { coreEmbed } from '../../util/embeds/core.js';
 import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
   ChannelType,
-  EmbedBuilder,
   PermissionsBitField,
 } from 'discord.js';
 
@@ -79,20 +76,16 @@ export async function openTicket(interaction, lang = 'en') {
   }
 
   const ticketChannel = channel.toString();
-  const replyEmbed = new EmbedBuilder()
+  const replyEmbed = coreEmbed('TICKET', lang)
     .setTitle(lang === 'de' ? 'Erfolgreich – Ticket erstellt' : 'Successfully - Ticket Created')
     .setDescription(
       lang === 'de'
         ? `Ticket erstellt. Hier ist dein Ticket: ${ticketChannel}`
         : `Ticket created. Here is your ticket: ${ticketChannel}`
-    )
-    .setFooter(FOOTER);
+    );
   await interaction.reply({ embeds: [replyEmbed], ephemeral: true, allowedMentions: { parse: [] } });
 
-  const embed = applyAuthor(new EmbedBuilder(), 'TICKET')
-    .setColor(COLOR)
-    .setFooter(FOOTER)
-    .setDescription(
+  const embed = coreEmbed('TICKET', lang).setDescription(
       lang === 'de'
         ? '> 🇩🇪 Bitte beschreibe dein Anliegen, während du wartest.'
         : '> 🇺🇸 Please describe your issue while you’re waiting.'

--- a/src/modules/tickets/panel.js
+++ b/src/modules/tickets/panel.js
@@ -1,22 +1,17 @@
 import {
-  EmbedBuilder,
   ActionRowBuilder,
   StringSelectMenuBuilder,
   StringSelectMenuOptionBuilder,
 } from 'discord.js';
-import { FOOTER } from '../../util/embeds/footer.js';
-import { applyAuthor } from '../../util/embeds/author.js';
-import { COLOR } from '../../util/embeds/color.js';
+import { coreEmbed } from '../../util/embeds/core.js';
 import { MENU_CUSTOM_ID, MENU_PLACEHOLDER, MENU_OPTION_EN, MENU_OPTION_DE } from './config.js';
 
 export function buildTicketPanel() {
-  const embed = applyAuthor(new EmbedBuilder(), 'TICKET')
+  const embed = coreEmbed('TICKET')
     .setDescription(
       `🇺🇸 **English**\n> Select which type of ticket you would like to open in the dropdown menu!\n\n` +
         `🇩🇪 **Deutsch**\n> Wähle im Dropdown-Menü aus, welche Art von Ticket du öffnen möchtest!`
-    )
-    .setColor(COLOR)
-    .setFooter(FOOTER);
+    );
 
   const optionEN = new StringSelectMenuOptionBuilder()
     .setValue(MENU_OPTION_EN.value)

--- a/src/modules/verify/embed.js
+++ b/src/modules/verify/embed.js
@@ -1,10 +1,8 @@
 /*
 ### Zweck: Baut die Verify-Embed samt Sprach- und Verify-Buttons.
 */
-import { EmbedBuilder, ButtonBuilder, ActionRowBuilder, ButtonStyle } from 'discord.js';
-import { FOOTER } from '../../util/embeds/footer.js';
-import { applyAuthorByLang } from '../../util/embeds/author.js';
-import { COLOR } from '../../util/embeds/color.js';
+import { ButtonBuilder, ActionRowBuilder, ButtonStyle } from 'discord.js';
+import { coreEmbed } from '../../util/embeds/core.js';
 import {
   VERIFY_BUTTON_ID,
   VERIFY_LANG_EN_ID,
@@ -46,13 +44,10 @@ export function buildVerifyEmbedAndComponents(lang = VERIFY_DEFAULT_LANG) {
         },
       ];
 
-  const embed = new EmbedBuilder()
-    .setColor(COLOR)
+  const embed = coreEmbed('VERIFY', lang)
     .setTitle(title)
     .setDescription(description)
-    .addFields(fields)
-    .setFooter(FOOTER);
-  applyAuthorByLang(embed, 'VERIFY', lang);
+    .addFields(fields);
 
   // ✅ Verify-Button (grün)
   const verifyButton = new ButtonBuilder()

--- a/src/modules/verify/interactions.js
+++ b/src/modules/verify/interactions.js
@@ -1,7 +1,6 @@
 /*
 ### Zweck: Handhabt Verify- und Sprachwechsel-Buttons.
 */
-import { EmbedBuilder } from 'discord.js';
 import {
   VERIFY_ROLE_ID,
   VERIFY_BUTTON_ID,
@@ -10,7 +9,8 @@ import {
   VERIFY_RESET_MS,
 } from './config.js';
 import { buildVerifyEmbedAndComponents } from './embed.js';
-import { FOOTER } from '../../util/embeds/footer.js';
+import { coreEmbed } from '../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../util/embeds/lang.js';
 import { logger } from '../../util/logging/logger.js';
 
 const verifyLogger = logger.withPrefix('verify');
@@ -18,16 +18,17 @@ const verifyLogger = logger.withPrefix('verify');
 const verifyLangTimers = new Map();
 
 export async function handleVerifyInteractions(interaction, client) {
+  const lang = detectLangFromInteraction(interaction);
+
   if (interaction.customId === VERIFY_BUTTON_ID) {
     const member =
       interaction.member ??
       (await interaction.guild.members.fetch(interaction.user.id).catch(() => null));
     if (!member) {
-      const embed = new EmbedBuilder()
+      const embed = coreEmbed('VERIFY', lang)
         .setColor(0xFFA500)
         .setTitle('Verification')
-        .setDescription('⚠️ Verification failed. Please try again or contact staff.')
-        .setFooter(FOOTER);
+        .setDescription('⚠️ Verification failed. Please try again or contact staff.');
       try {
         await interaction.reply({ embeds: [embed], ephemeral: true });
       } catch (err) {
@@ -38,11 +39,10 @@ export async function handleVerifyInteractions(interaction, client) {
     }
 
     if (member.roles.cache.has(VERIFY_ROLE_ID)) {
-      const embed = new EmbedBuilder()
+      const embed = coreEmbed('VERIFY', lang)
         .setColor(0x00ff00)
         .setTitle('Verification')
-        .setDescription('ℹ️ You are already verified.')
-        .setFooter(FOOTER);
+        .setDescription('ℹ️ You are already verified.');
       try {
         await interaction.reply({ embeds: [embed], ephemeral: true });
       } catch (err) {
@@ -53,19 +53,17 @@ export async function handleVerifyInteractions(interaction, client) {
 
     try {
       await member.roles.add(VERIFY_ROLE_ID);
-      const embed = new EmbedBuilder()
+      const embed = coreEmbed('VERIFY', lang)
         .setColor(0x00ff00)
         .setTitle('Verification')
-        .setDescription('✅ You are now verified!')
-        .setFooter(FOOTER);
+        .setDescription('✅ You are now verified!');
       await interaction.reply({ embeds: [embed], ephemeral: true });
     } catch (err) {
       verifyLogger.warn('Rolle konnte nicht vergeben', err);
-      const embed = new EmbedBuilder()
+      const embed = coreEmbed('VERIFY', lang)
         .setColor(0xFFA500)
         .setTitle('Verification')
-        .setDescription('⚠️ Verification failed. Please try again or contact staff.')
-        .setFooter(FOOTER);
+        .setDescription('⚠️ Verification failed. Please try again or contact staff.');
       try {
         await interaction.reply({ embeds: [embed], ephemeral: true });
       } catch (err) {

--- a/src/util/embeds/author.js
+++ b/src/util/embeds/author.js
@@ -3,6 +3,10 @@ export const AUTHOR_ICON =
 
 // Für jede Einbettung das passende EN- und DE-Label
 export const AUTHORS = {
+  WELCOME: {
+    en: "The Core - Welcome",
+    de: "The Core - Willkommen",
+  },
   TICKET: {
     en: "The Core - Ticket System",
     de: "The Core - Ticket System",
@@ -24,8 +28,8 @@ export const AUTHORS = {
     de: "The Core - Ankündigungen",
   },
   LOGS: {
-    en: "The Core – Logs",
-    de: "The Core – Logs",
+    en: "The Core - Logs",
+    de: "The Core - Logs",
   },
 };
 
@@ -34,7 +38,7 @@ export const AUTHORS = {
  * und gewählter Sprache ('en' oder 'de'). Fällt auf 'en' oder 'The Core' zurück, wenn nichts gefunden wird.
  *
  * @param {EmbedBuilder} embed
- * @param {"VERIFY"|"RULES"|"TEAM"|"ANN"|"LOGS"} context
+ * @param {"WELCOME"|"TICKET"|"VERIFY"|"RULES"|"TEAM"|"ANN"|"LOGS"} context
  * @param {"en"|"de"} lang
  * @returns {EmbedBuilder}
  */

--- a/src/util/embeds/core.js
+++ b/src/util/embeds/core.js
@@ -1,0 +1,13 @@
+/*
+### Zweck: Zentrale Factory für Embeds mit einheitlicher Gestaltung.
+*/
+import { EmbedBuilder } from 'discord.js';
+import { COLOR } from './color.js';
+import { FOOTER } from './footer.js';
+import { applyAuthorByLang } from './author.js';
+
+export function coreEmbed(context, lang = 'en') {
+  const embed = new EmbedBuilder().setColor(COLOR).setFooter(FOOTER);
+  applyAuthorByLang(embed, context, lang);
+  return embed;
+}

--- a/src/util/embeds/lang.js
+++ b/src/util/embeds/lang.js
@@ -1,0 +1,8 @@
+/*
+### Zweck: Hilfsfunktion zur Spracherkennung für Interaktionen.
+*/
+export function detectLangFromInteraction(i) {
+  const locale = i?.locale ?? i?.guild?.preferredLocale ?? 'en';
+  const normalised = typeof locale === 'string' ? locale.toLowerCase() : 'en';
+  return normalised.startsWith('de') ? 'de' : 'en';
+}

--- a/src/util/logger.test.js
+++ b/src/util/logger.test.js
@@ -232,7 +232,7 @@ describe('setupDiscordLogging', () => {
     expect(payload.embeds).toHaveLength(1);
     const embed = payload.embeds[0];
     expect(embed.data.description).toBe('general entry');
-    expect(embed.data.author?.name).toBe('The Core – Logs');
+    expect(embed.data.author?.name).toBe('The Core - Logs');
     expect(embed.data.fields ?? []).toEqual([]);
 
     unsubscribe();


### PR DESCRIPTION
## Summary
- add a shared core embed factory and locale detector for consistent author, color, and footer
- migrate welcome, verify, rules, team, ticket, ping, and clear flows to use the factory-generated embeds
- normalize author labels and update the logging test expectation for the new format

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e01301b3f0832d992856693cded72b