### PR TITLE
Add moderation system with persistence and worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "discord.js": "^14.22.1"
+        "discord.js": "^14.22.1",
+        "pg": "^8.11.5"
       },
       "devDependencies": {
         "eslint": "^8.57.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "discord.js": "^14.22.1"
+    "discord.js": "^14.22.1",
+    "pg": "^8.11.5"
   },
   "devDependencies": {
     "nodemon": "^3.1.10",

--- a/src/commands/ban/command.js
+++ b/src/commands/ban/command.js
@@ -1,0 +1,71 @@
+import { ApplicationCommandOptionType } from 'discord.js';
+import { randomUUID } from 'node:crypto';
+import { coreEmbed } from '../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../util/embeds/lang.js';
+import { TEAM_ROLE_ID } from '../../modules/moderation/config.js';
+import { ACTION, ERROR_COLOR } from '../../modules/moderation/constants.js';
+import { createCase } from '../../modules/moderation/storage/repo.js';
+import { buildDurationSelect } from '../../modules/moderation/ui/durationSelect.js';
+import { buildReasonsSelect } from '../../modules/moderation/ui/reasonsSelect.js';
+import { buildConfirmButtons } from '../../modules/moderation/ui/confirmButtons.js';
+
+export default {
+  name: 'ban',
+  description: 'Ban a member from the guild',
+  dmPermission: false,
+  options: [
+    {
+      name: 'target',
+      description: 'Member to ban',
+      type: ApplicationCommandOptionType.User,
+      required: true,
+    },
+  ],
+  async execute(interaction) {
+    if (!interaction.guild || interaction.guild.id !== process.env.GUILD_ID) {
+      return;
+    }
+
+    const lang = detectLangFromInteraction(interaction);
+    const embed = coreEmbed('ANN', lang);
+
+    if (!interaction.member?.roles?.cache?.has(TEAM_ROLE_ID)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Du benötigst die Team-Rolle.' : 'You need the team role.');
+      await interaction.reply({ ephemeral: true, embeds: [embed] });
+      return;
+    }
+
+    const target = interaction.options.getUser('target', true);
+    const caseId = randomUUID();
+    await createCase({
+      id: caseId,
+      guildId: interaction.guild.id,
+      userId: target.id,
+      moderatorId: interaction.user.id,
+      actionType: ACTION.BAN,
+    });
+
+    const durationRow = buildDurationSelect(ACTION.BAN, caseId, lang);
+    const reasonRow = buildReasonsSelect(caseId, lang);
+    const confirmRow = buildConfirmButtons(ACTION.BAN, caseId, lang);
+
+    embed
+      .setDescription(
+        lang === 'de'
+          ? `Bitte konfiguriere den Bann für <@${target.id}> (Case #${caseId}).`
+          : `Configure the ban for <@${target.id}> (Case #${caseId}).`
+      )
+      .addFields({
+        name: lang === 'de' ? 'Ziel' : 'Target',
+        value: `<@${target.id}> (${target.tag ?? target.id})`,
+      });
+
+    await interaction.reply({
+      ephemeral: true,
+      embeds: [embed],
+      components: [durationRow, reasonRow, confirmRow],
+    });
+  },
+};

--- a/src/commands/kick/command.js
+++ b/src/commands/kick/command.js
@@ -1,0 +1,69 @@
+import { ApplicationCommandOptionType } from 'discord.js';
+import { randomUUID } from 'node:crypto';
+import { coreEmbed } from '../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../util/embeds/lang.js';
+import { TEAM_ROLE_ID } from '../../modules/moderation/config.js';
+import { ACTION, ERROR_COLOR } from '../../modules/moderation/constants.js';
+import { createCase } from '../../modules/moderation/storage/repo.js';
+import { buildReasonsSelect } from '../../modules/moderation/ui/reasonsSelect.js';
+import { buildConfirmButtons } from '../../modules/moderation/ui/confirmButtons.js';
+
+export default {
+  name: 'kick',
+  description: 'Kick a member from the guild',
+  dmPermission: false,
+  options: [
+    {
+      name: 'target',
+      description: 'Member to kick',
+      type: ApplicationCommandOptionType.User,
+      required: true,
+    },
+  ],
+  async execute(interaction) {
+    if (!interaction.guild || interaction.guild.id !== process.env.GUILD_ID) {
+      return;
+    }
+
+    const lang = detectLangFromInteraction(interaction);
+    const embed = coreEmbed('ANN', lang);
+
+    if (!interaction.member?.roles?.cache?.has(TEAM_ROLE_ID)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Du benötigst die Team-Rolle.' : 'You need the team role.');
+      await interaction.reply({ ephemeral: true, embeds: [embed] });
+      return;
+    }
+
+    const target = interaction.options.getUser('target', true);
+    const caseId = randomUUID();
+    await createCase({
+      id: caseId,
+      guildId: interaction.guild.id,
+      userId: target.id,
+      moderatorId: interaction.user.id,
+      actionType: ACTION.KICK,
+    });
+
+    const reasonRow = buildReasonsSelect(caseId, lang);
+    const confirmRow = buildConfirmButtons(ACTION.KICK, caseId, lang);
+
+    embed
+      .setDescription(
+        lang === 'de'
+          ? `Bitte bestätige den Kick für <@${target.id}> (Case #${caseId}).`
+          : `Configure the kick for <@${target.id}> (Case #${caseId}).`
+      )
+      .addFields({
+        name: lang === 'de' ? 'Ziel' : 'Target',
+        value: `<@${target.id}> (${target.tag ?? target.id})`,
+      });
+
+    await interaction.reply({
+      ephemeral: true,
+      embeds: [embed],
+      components: [reasonRow, confirmRow],
+    });
+  },
+};

--- a/src/commands/timeout/command.js
+++ b/src/commands/timeout/command.js
@@ -1,0 +1,71 @@
+import { ApplicationCommandOptionType } from 'discord.js';
+import { randomUUID } from 'node:crypto';
+import { coreEmbed } from '../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../util/embeds/lang.js';
+import { TEAM_ROLE_ID } from '../../modules/moderation/config.js';
+import { ACTION, ERROR_COLOR } from '../../modules/moderation/constants.js';
+import { createCase } from '../../modules/moderation/storage/repo.js';
+import { buildDurationSelect } from '../../modules/moderation/ui/durationSelect.js';
+import { buildReasonsSelect } from '../../modules/moderation/ui/reasonsSelect.js';
+import { buildConfirmButtons } from '../../modules/moderation/ui/confirmButtons.js';
+
+export default {
+  name: 'timeout',
+  description: 'Timeout a member',
+  dmPermission: false,
+  options: [
+    {
+      name: 'target',
+      description: 'Member to timeout',
+      type: ApplicationCommandOptionType.User,
+      required: true,
+    },
+  ],
+  async execute(interaction) {
+    if (!interaction.guild || interaction.guild.id !== process.env.GUILD_ID) {
+      return;
+    }
+
+    const lang = detectLangFromInteraction(interaction);
+    const embed = coreEmbed('ANN', lang);
+
+    if (!interaction.member?.roles?.cache?.has(TEAM_ROLE_ID)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Du benötigst die Team-Rolle.' : 'You need the team role.');
+      await interaction.reply({ ephemeral: true, embeds: [embed] });
+      return;
+    }
+
+    const target = interaction.options.getUser('target', true);
+    const caseId = randomUUID();
+    await createCase({
+      id: caseId,
+      guildId: interaction.guild.id,
+      userId: target.id,
+      moderatorId: interaction.user.id,
+      actionType: ACTION.TIMEOUT,
+    });
+
+    const durationRow = buildDurationSelect(ACTION.TIMEOUT, caseId, lang);
+    const reasonRow = buildReasonsSelect(caseId, lang);
+    const confirmRow = buildConfirmButtons(ACTION.TIMEOUT, caseId, lang);
+
+    embed
+      .setDescription(
+        lang === 'de'
+          ? `Bitte konfiguriere den Timeout für <@${target.id}> (Case #${caseId}).`
+          : `Configure the timeout for <@${target.id}> (Case #${caseId}).`
+      )
+      .addFields({
+        name: lang === 'de' ? 'Ziel' : 'Target',
+        value: `<@${target.id}> (${target.tag ?? target.id})`,
+      });
+
+    await interaction.reply({
+      ephemeral: true,
+      embeds: [embed],
+      components: [durationRow, reasonRow, confirmRow],
+    });
+  },
+};

--- a/src/commands/unban/command.js
+++ b/src/commands/unban/command.js
@@ -1,0 +1,77 @@
+import { ApplicationCommandOptionType } from 'discord.js';
+import { randomUUID } from 'node:crypto';
+import { coreEmbed } from '../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../util/embeds/lang.js';
+import { TEAM_ROLE_ID } from '../../modules/moderation/config.js';
+import { ACTION, ERROR_COLOR } from '../../modules/moderation/constants.js';
+import { createCase } from '../../modules/moderation/storage/repo.js';
+import { buildReasonsSelect } from '../../modules/moderation/ui/reasonsSelect.js';
+import { buildConfirmButtons } from '../../modules/moderation/ui/confirmButtons.js';
+
+export default {
+  name: 'unban',
+  description: 'Unban a user',
+  dmPermission: false,
+  options: [
+    {
+      name: 'user',
+      description: 'ID of the user to unban',
+      type: ApplicationCommandOptionType.String,
+      required: true,
+    },
+  ],
+  async execute(interaction) {
+    if (!interaction.guild || interaction.guild.id !== process.env.GUILD_ID) {
+      return;
+    }
+
+    const lang = detectLangFromInteraction(interaction);
+    const embed = coreEmbed('ANN', lang);
+
+    if (!interaction.member?.roles?.cache?.has(TEAM_ROLE_ID)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Du benötigst die Team-Rolle.' : 'You need the team role.');
+      await interaction.reply({ ephemeral: true, embeds: [embed] });
+      return;
+    }
+
+    const userId = interaction.options.getString('user', true).replace(/[^0-9]/g, '');
+    if (!userId) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Bitte gib eine gültige ID an.' : 'Please provide a valid ID.');
+      await interaction.reply({ ephemeral: true, embeds: [embed] });
+      return;
+    }
+
+    const caseId = randomUUID();
+    await createCase({
+      id: caseId,
+      guildId: interaction.guild.id,
+      userId,
+      moderatorId: interaction.user.id,
+      actionType: ACTION.UNBAN,
+    });
+
+    const reasonRow = buildReasonsSelect(caseId, lang);
+    const confirmRow = buildConfirmButtons(ACTION.UNBAN, caseId, lang);
+
+    embed
+      .setDescription(
+        lang === 'de'
+          ? `Bitte bestätige die Entbannung für <@${userId}> (Case #${caseId}).`
+          : `Configure the unban for <@${userId}> (Case #${caseId}).`
+      )
+      .addFields({
+        name: lang === 'de' ? 'Ziel' : 'Target',
+        value: `<@${userId}> (${userId})`,
+      });
+
+    await interaction.reply({
+      ephemeral: true,
+      embeds: [embed],
+      components: [reasonRow, confirmRow],
+    });
+  },
+};

--- a/src/commands/warn/command.js
+++ b/src/commands/warn/command.js
@@ -1,0 +1,69 @@
+import { ApplicationCommandOptionType } from 'discord.js';
+import { randomUUID } from 'node:crypto';
+import { coreEmbed } from '../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../util/embeds/lang.js';
+import { TEAM_ROLE_ID } from '../../modules/moderation/config.js';
+import { ACTION, ERROR_COLOR } from '../../modules/moderation/constants.js';
+import { createCase } from '../../modules/moderation/storage/repo.js';
+import { buildReasonsSelect } from '../../modules/moderation/ui/reasonsSelect.js';
+import { buildConfirmButtons } from '../../modules/moderation/ui/confirmButtons.js';
+
+export default {
+  name: 'warn',
+  description: 'Warn a member',
+  dmPermission: false,
+  options: [
+    {
+      name: 'target',
+      description: 'Member to warn',
+      type: ApplicationCommandOptionType.User,
+      required: true,
+    },
+  ],
+  async execute(interaction) {
+    if (!interaction.guild || interaction.guild.id !== process.env.GUILD_ID) {
+      return;
+    }
+
+    const lang = detectLangFromInteraction(interaction);
+    const embed = coreEmbed('ANN', lang);
+
+    if (!interaction.member?.roles?.cache?.has(TEAM_ROLE_ID)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Du benötigst die Team-Rolle.' : 'You need the team role.');
+      await interaction.reply({ ephemeral: true, embeds: [embed] });
+      return;
+    }
+
+    const target = interaction.options.getUser('target', true);
+    const caseId = randomUUID();
+    await createCase({
+      id: caseId,
+      guildId: interaction.guild.id,
+      userId: target.id,
+      moderatorId: interaction.user.id,
+      actionType: ACTION.WARN,
+    });
+
+    const reasonRow = buildReasonsSelect(caseId, lang);
+    const confirmRow = buildConfirmButtons(ACTION.WARN, caseId, lang);
+
+    embed
+      .setDescription(
+        lang === 'de'
+          ? `Bitte bestätige die Verwarnung für <@${target.id}> (Case #${caseId}).`
+          : `Configure the warning for <@${target.id}> (Case #${caseId}).`
+      )
+      .addFields({
+        name: lang === 'de' ? 'Ziel' : 'Target',
+        value: `<@${target.id}> (${target.tag ?? target.id})`,
+      });
+
+    await interaction.reply({
+      ephemeral: true,
+      embeds: [embed],
+      components: [reasonRow, confirmRow],
+    });
+  },
+};

--- a/src/events/interactionCreate/handler.js
+++ b/src/events/interactionCreate/handler.js
@@ -8,6 +8,10 @@ import { handleRulesButtons } from '../../modules/rules/interactions.js';
 import { TEAM_BUTTON_ID_EN, TEAM_BUTTON_ID_DE } from '../../modules/teamlist/config.js';
 import { handleTeamButtons } from '../../modules/teamlist/interactions.js';
 import { logger } from '../../util/logging/logger.js';
+import { isDurationSelect, handleDurationSelect } from '../../modules/moderation/ui/durationSelect.js';
+import { isReasonsSelect, handleReasonsSelect } from '../../modules/moderation/ui/reasonsSelect.js';
+import { isCustomReasonModal, handleCustomReasonModal } from '../../modules/moderation/ui/customReasonModal.js';
+import { isConfirmButton, handleConfirmButton } from '../../modules/moderation/ui/confirmButtons.js';
 import {
   MENU_CUSTOM_ID,
   BTN_CLAIM_ID,
@@ -46,6 +50,10 @@ export default {
       return;
     }
     if (interaction.isButton()) {
+      if (isConfirmButton(interaction)) {
+        await handleConfirmButton(interaction);
+        return;
+      }
       if (
         interaction.customId === VERIFY_BUTTON_ID ||
         interaction.customId === VERIFY_LANG_EN_ID ||
@@ -62,6 +70,22 @@ export default {
         await handleRulesButtons(interaction, client);
         return;
       }
+    }
+
+    if (interaction.isStringSelectMenu()) {
+      if (isDurationSelect(interaction)) {
+        await handleDurationSelect(interaction);
+        return;
+      }
+      if (isReasonsSelect(interaction)) {
+        await handleReasonsSelect(interaction);
+        return;
+      }
+    }
+
+    if (interaction.isModalSubmit() && isCustomReasonModal(interaction)) {
+      await handleCustomReasonModal(interaction);
+      return;
     }
 
     if (!interaction.isChatInputCommand()) return;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import eventLoader from './loaders/eventLoader.js';
 import { logger } from './util/logging/logger.js';
 import { setupDiscordLogging } from './util/logging/discordTransport.js';
 import { getLogChannelIds } from './util/logging/config.js';
+import { startModerationScheduler } from './modules/moderation/worker/scheduler.js';
 
 const startLogger = logger.withPrefix('start');
 const shutdownLogger = logger.withPrefix('beenden');
@@ -54,5 +55,9 @@ const eventsDir = process.env.EVENTS_DIR
   ? path.resolve(process.cwd(), process.env.EVENTS_DIR)
   : undefined;
 await eventLoader(client, eventsDir);
+
+client.once('ready', () => {
+  startModerationScheduler(client);
+});
 
 await client.login(process.env.TOKEN);

--- a/src/modules/moderation/config.js
+++ b/src/modules/moderation/config.js
@@ -1,0 +1,24 @@
+export const MOD_LOG_CHANNEL_ID = '1418659303916703794';
+export const TEAM_ROLE_ID = '1354916696527208693';
+export const BAN_PRESETS = ['1d', '3d', '7d', '14d', '30d', 'permanent'];
+export const TIMEOUT_PRESETS = ['10m', '1h', '1d', '3d', '7d'];
+export const REASON_CODES = ['SPAM', 'HARASS', 'NSFW', 'ALT', 'D0X', 'CUSTOM'];
+
+export const REASON_LABELS = {
+  en: {
+    SPAM: 'Spam / Flooding',
+    HARASS: 'Harassment',
+    NSFW: 'NSFW Content',
+    ALT: 'Alt Account',
+    D0X: 'Doxxing',
+    CUSTOM: 'Custom Reason',
+  },
+  de: {
+    SPAM: 'Spam / Flood',
+    HARASS: 'Belästigung',
+    NSFW: 'NSFW-Inhalte',
+    ALT: 'Alt-Account',
+    D0X: 'Doxxing',
+    CUSTOM: 'Eigener Grund',
+  },
+};

--- a/src/modules/moderation/constants.js
+++ b/src/modules/moderation/constants.js
@@ -1,0 +1,29 @@
+export const ACTION = {
+  BAN: 'BAN',
+  UNBAN: 'UNBAN',
+  TIMEOUT: 'TIMEOUT',
+  KICK: 'KICK',
+  WARN: 'WARN',
+};
+
+export const STATUS = {
+  PENDING: 'PENDING',
+  ACTIVE: 'ACTIVE',
+  LIFTED: 'LIFTED',
+  FAILED: 'FAILED',
+};
+
+export const SUCCESS_COLOR = 0x57f287;
+export const ERROR_COLOR = 0xff0000;
+
+export const CUSTOM_IDS = {
+  DURATION_SELECT: 'MOD_DUR_SELECT',
+  REASON_SELECT: 'MOD_REASON_SELECT',
+  REASON_MODAL: 'MOD_REASON_MODAL',
+  CONFIRM_BUTTON: 'MOD_CONFIRM',
+};
+
+export const CONFIRM_ACTION = {
+  CONFIRM: 'CONFIRM',
+  CANCEL: 'CANCEL',
+};

--- a/src/modules/moderation/service/audit.js
+++ b/src/modules/moderation/service/audit.js
@@ -1,0 +1,37 @@
+import { AuditLogEvent } from 'discord.js';
+import { logger } from '../../../util/logging/logger.js';
+import { ACTION } from '../constants.js';
+import { getCaseById, updateCaseAudit } from '../storage/repo.js';
+
+const auditLogger = logger.withPrefix('moderation:audit');
+
+const AUDIT_EVENT_MAP = {
+  [ACTION.BAN]: AuditLogEvent.MemberBanAdd,
+  [ACTION.UNBAN]: AuditLogEvent.MemberBanRemove,
+  [ACTION.TIMEOUT]: AuditLogEvent.MemberUpdate,
+  [ACTION.KICK]: AuditLogEvent.MemberKick,
+  [ACTION.WARN]: null,
+};
+
+export async function attachAuditInfo(guild, actionType, caseId) {
+  if (!guild || !caseId) return null;
+  const caseRecord = await getCaseById(caseId);
+  if (!caseRecord) return null;
+
+  const type = AUDIT_EVENT_MAP[actionType];
+  if (!type) {
+    return null;
+  }
+
+  try {
+    const audit = await guild.fetchAuditLogs({ limit: 5, type });
+    const entry = Array.from(audit.entries.values()).find((item) => item.target?.id === caseRecord.userId);
+    if (entry) {
+      await updateCaseAudit(caseId, entry.id);
+      return entry.id;
+    }
+  } catch (error) {
+    auditLogger.warn('Failed to fetch audit log entry:', error);
+  }
+  return null;
+}

--- a/src/modules/moderation/service/composeReason.js
+++ b/src/modules/moderation/service/composeReason.js
@@ -1,0 +1,49 @@
+import { REASON_LABELS } from '../config.js';
+
+const REASON_TEMPLATES = {
+  en: {
+    SPAM: 'Repeated spamming in text or voice channels despite prior warnings',
+    HARASS: 'Targeted insults and harassment of members',
+    NSFW: 'Sharing inappropriate NSFW material in unsuitable channels',
+    ALT: 'Using alternative accounts to evade punishments',
+    D0X: 'Sharing personal information of others (doxxing)',
+  },
+  de: {
+    SPAM: 'Mehrfaches Spamming in Text- oder Voice-Kanälen trotz Verwarnungen',
+    HARASS: 'Gezielte Beleidigungen und Belästigung von Mitgliedern',
+    NSFW: 'Veröffentlichung unangemessener NSFW-Inhalte in ungeeigneten Kanälen',
+    ALT: 'Nutzung von Alt-Accounts zur Umgehung von Strafen',
+    D0X: 'Veröffentlichung persönlicher Daten (Doxxing)',
+  },
+};
+
+export function composeReasonText(codes = [], customReason = '', lang = 'en') {
+  const language = lang === 'de' ? 'de' : 'en';
+  const templates = REASON_TEMPLATES[language];
+  const uniqueCodes = Array.from(new Set(Array.isArray(codes) ? codes : [])).filter((code) =>
+    Object.prototype.hasOwnProperty.call(templates, code)
+  );
+
+  const sentences = uniqueCodes.map((code) => templates[code]);
+  let text = '';
+
+  if (sentences.length === 1) {
+    text = `${sentences[0]}.`;
+  } else if (sentences.length > 1) {
+    const last = sentences.pop();
+    const joinWord = language === 'de' ? ' und ' : ' and ';
+    text = `${sentences.join(', ')}${joinWord}${last}.`;
+  }
+
+  const custom = typeof customReason === 'string' ? customReason.trim() : '';
+  if (custom) {
+    text = text ? `${text} ${custom}` : custom;
+  }
+
+  if (!text) {
+    const fallback = REASON_LABELS[language]?.CUSTOM ?? 'Custom reason';
+    return fallback;
+  }
+
+  return text;
+}

--- a/src/modules/moderation/service/dm.js
+++ b/src/modules/moderation/service/dm.js
@@ -1,0 +1,57 @@
+import { coreEmbed } from '../../../util/embeds/core.js';
+
+const ACTION_LABELS = {
+  en: {
+    BAN: 'Ban',
+    UNBAN: 'Unban',
+    TIMEOUT: 'Timeout',
+    KICK: 'Kick',
+    WARN: 'Warning',
+  },
+  de: {
+    BAN: 'Bann',
+    UNBAN: 'Entbannung',
+    TIMEOUT: 'Timeout',
+    KICK: 'Kick',
+    WARN: 'Verwarnung',
+  },
+};
+
+export async function sendUserDM(userId, payload, lang = 'en') {
+  const language = lang === 'de' ? 'de' : 'en';
+  const { client, guildName, actionType, reasonText, durationText, caseId } = payload;
+  if (!client) {
+    return false;
+  }
+
+  try {
+    const user = await client.users.fetch(userId);
+    const actionLabel = ACTION_LABELS[language][actionType] ?? actionType;
+    const embed = coreEmbed('ANN', language)
+      .setTitle(actionLabel)
+      .setDescription(
+        language === 'de'
+          ? `Du erhältst diese Nachricht vom Server **${guildName}**.`
+          : `You are receiving this message from **${guildName}**.`
+      )
+      .addFields(
+        language === 'de'
+          ? { name: 'Maßnahme', value: actionLabel, inline: true }
+          : { name: 'Action', value: actionLabel, inline: true },
+        language === 'de'
+          ? { name: 'Fallnummer', value: `#${caseId}`, inline: true }
+          : { name: 'Case ID', value: `#${caseId}`, inline: true },
+        language === 'de'
+          ? { name: 'Dauer', value: durationText, inline: true }
+          : { name: 'Duration', value: durationText, inline: true },
+        language === 'de'
+          ? { name: 'Begründung', value: reasonText }
+          : { name: 'Reason', value: reasonText }
+      );
+
+    await user.send({ embeds: [embed] });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/modules/moderation/service/exec.js
+++ b/src/modules/moderation/service/exec.js
@@ -1,0 +1,357 @@
+import { PermissionsBitField } from 'discord.js';
+import { randomUUID } from 'node:crypto';
+import { coreEmbed } from '../../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../../util/embeds/lang.js';
+import { TEAM_ROLE_ID } from '../config.js';
+import { ACTION, STATUS, SUCCESS_COLOR, ERROR_COLOR } from '../constants.js';
+import { composeReasonText } from './composeReason.js';
+import { sendUserDM } from './dm.js';
+import { sendModLog } from './log.js';
+import { attachAuditInfo } from './audit.js';
+import {
+  createCase,
+  getCaseById,
+  updateCaseDM,
+  updateCaseReasonCodes,
+  updateCaseCustomReason,
+  updateCaseReasonText,
+  updateCaseStatus,
+  markCaseFailed,
+} from '../storage/repo.js';
+
+const REQUIRED_PERMISSIONS = {
+  [ACTION.BAN]: PermissionsBitField.Flags.BanMembers,
+  [ACTION.UNBAN]: PermissionsBitField.Flags.BanMembers,
+  [ACTION.TIMEOUT]: PermissionsBitField.Flags.ModerateMembers,
+  [ACTION.KICK]: PermissionsBitField.Flags.KickMembers,
+  [ACTION.WARN]: PermissionsBitField.Flags.ModerateMembers,
+};
+
+function buildResponseEmbed(interaction, lang, color) {
+  const embed = coreEmbed('ANN', lang);
+  if (color) {
+    embed.setColor(color);
+  }
+  return embed;
+}
+
+function ensureGuild(interaction) {
+  if (!interaction.guild) {
+    throw new Error('Interaction ohne Guild');
+  }
+}
+
+function getLanguage(interaction, providedLang) {
+  if (providedLang) return providedLang;
+  if (interaction) {
+    return detectLangFromInteraction(interaction);
+  }
+  return 'en';
+}
+
+function calculateDuration(caseRecord, startTs) {
+  if (!caseRecord) {
+    return { permanent: false, endTs: null, durationMs: null, display: '—' };
+  }
+  if (caseRecord.permanent) {
+    return { permanent: true, endTs: null, durationMs: null, display: 'Permanent' };
+  }
+  if (!caseRecord.endTs || !caseRecord.createdAt) {
+    return { permanent: false, endTs: null, durationMs: null, display: '—' };
+  }
+  const durationMs = Math.max(caseRecord.endTs.getTime() - caseRecord.createdAt.getTime(), 0);
+  const computedEnd = new Date(startTs.getTime() + durationMs);
+  return {
+    permanent: false,
+    durationMs,
+    endTs: computedEnd,
+    display: formatDuration(durationMs),
+  };
+}
+
+function formatDuration(ms) {
+  if (!ms || Number.isNaN(ms) || ms <= 0) {
+    return '—';
+  }
+  const totalSeconds = Math.floor(ms / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts = [];
+  if (days) parts.push(`${days}d`);
+  if (hours) parts.push(`${hours}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  if (!parts.length && seconds) parts.push(`${seconds}s`);
+  return parts.join(' ');
+}
+
+function hasTeamRole(member) {
+  return Boolean(member?.roles?.cache?.has(TEAM_ROLE_ID));
+}
+
+function compareHierarchy(invoker, target) {
+  if (!invoker || !target) return true;
+  if (invoker.guild?.ownerId === invoker.id) return true;
+  const invokerHighest = invoker.roles?.highest;
+  const targetHighest = target.roles?.highest;
+  if (!invokerHighest || !targetHighest) return true;
+  return invokerHighest.comparePositionTo(targetHighest) > 0;
+}
+
+function compareBotHierarchy(guild, target) {
+  if (!guild?.members?.me || !target) return true;
+  const botHighest = guild.members.me.roles?.highest;
+  const targetHighest = target.roles?.highest;
+  if (!botHighest || !targetHighest) return true;
+  return botHighest.comparePositionTo(targetHighest) > 0;
+}
+
+export async function executeAction(params) {
+  const {
+    interaction,
+    caseId: providedCaseId,
+    actionType,
+    guild,
+    moderator,
+    targetMember,
+    targetUser,
+    reasonCodes,
+    customReason,
+    lang: explicitLang,
+  } = params;
+
+  ensureGuild(interaction ?? { guild });
+  const language = getLanguage(interaction, explicitLang);
+  const embed = buildResponseEmbed(interaction, language);
+
+  if (!hasTeamRole(moderator)) {
+    embed
+      .setColor(ERROR_COLOR)
+      .setDescription(
+        language === 'de'
+          ? 'Du benötigst die Team-Rolle, um diesen Befehl zu nutzen.'
+          : 'You need the team role to execute this command.'
+      );
+    return { ok: false, embed };
+  }
+
+  const requiredPermission = REQUIRED_PERMISSIONS[actionType];
+  if (requiredPermission && !moderator.permissions?.has(requiredPermission)) {
+    embed
+      .setColor(ERROR_COLOR)
+      .setDescription(
+        language === 'de'
+          ? 'Dir fehlen die erforderlichen Discord-Berechtigungen.'
+          : 'You are missing the required Discord permission.'
+      );
+    return { ok: false, embed };
+  }
+
+  if (requiredPermission && !guild.members.me?.permissions?.has(requiredPermission)) {
+    embed
+      .setColor(ERROR_COLOR)
+      .setDescription(
+        language === 'de'
+          ? 'Der Bot verfügt nicht über die nötigen Berechtigungen.'
+          : 'The bot lacks the required permission to execute this action.'
+      );
+    return { ok: false, embed };
+  }
+
+  if (hasTeamRole(targetMember)) {
+    embed
+      .setColor(ERROR_COLOR)
+      .setDescription(
+        language === 'de'
+          ? 'Aktion blockiert: Ziel gehört zum Team.'
+          : 'Action blocked: target is part of the team.'
+      );
+    return { ok: false, embed };
+  }
+
+  if (targetMember) {
+    if (!compareHierarchy(moderator, targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(
+          language === 'de'
+            ? 'Du kannst keine Mitglieder mit gleicher oder höherer Rolle moderieren.'
+            : 'You cannot moderate members with equal or higher role.'
+        );
+      return { ok: false, embed };
+    }
+    if (!compareBotHierarchy(guild, targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(
+          language === 'de'
+            ? 'Die Bot-Rolle ist nicht hoch genug, um diese Aktion auszuführen.'
+            : 'The bot role hierarchy prevents this action.'
+        );
+      return { ok: false, embed };
+    }
+  }
+
+  const caseId = providedCaseId ?? randomUUID();
+  let caseRecord = providedCaseId ? await getCaseById(caseId) : null;
+
+  if (!caseRecord) {
+    caseRecord = await createCase({
+      id: caseId,
+      guildId: guild.id,
+      userId: targetMember?.id ?? targetUser?.id,
+      moderatorId: moderator.id,
+      actionType,
+      reasonCodes,
+      customReason,
+    });
+  } else {
+    if (reasonCodes) {
+      await updateCaseReasonCodes(caseId, reasonCodes);
+      caseRecord.reasonCodes = reasonCodes;
+    }
+    if (typeof customReason === 'string') {
+      await updateCaseCustomReason(caseId, customReason);
+      caseRecord.customReason = customReason;
+    }
+  }
+
+  const effectiveReasonCodes = caseRecord.reasonCodes ?? reasonCodes ?? [];
+  const effectiveCustom = caseRecord.customReason ?? customReason ?? '';
+
+  if (!effectiveReasonCodes.length) {
+    embed
+      .setColor(ERROR_COLOR)
+      .setDescription(
+        language === 'de'
+          ? 'Bitte wähle mindestens einen Grund aus.'
+          : 'Please select at least one reason.'
+      );
+    return { ok: false, embed };
+  }
+
+  const reasonText = composeReasonText(effectiveReasonCodes, effectiveCustom, language);
+  await updateCaseReasonText(caseId, reasonText);
+
+  const startTs = new Date();
+  const durationInfo = calculateDuration(caseRecord, startTs);
+
+  const dmOk = await sendUserDM(caseRecord.userId, {
+    client: guild.client,
+    guildName: guild.name,
+    actionType,
+    reasonText,
+    durationText: durationInfo.permanent
+      ? language === 'de'
+        ? 'Permanent'
+        : 'Permanent'
+      : durationInfo.display,
+    caseId,
+  }, language);
+  await updateCaseDM(caseId, dmOk);
+
+  const auditReason = `${reasonText} | Case #${caseId}`.slice(0, 512);
+  const targetId = caseRecord.userId;
+  const result = { ok: true, embed, caseId, reasonText, dmOk };
+
+  try {
+    switch (actionType) {
+      case ACTION.BAN: {
+        await guild.members.ban(targetId, {
+          reason: auditReason,
+          deleteMessageSeconds: 86400,
+        });
+        break;
+      }
+      case ACTION.UNBAN: {
+        await guild.members.unban(targetId, auditReason);
+        break;
+      }
+      case ACTION.TIMEOUT: {
+        if (!targetMember) {
+          throw new Error('Target member missing for timeout');
+        }
+        if (!durationInfo.durationMs) {
+          throw new Error('Timeout duration missing');
+        }
+        await targetMember.timeout(durationInfo.durationMs, auditReason);
+        break;
+      }
+      case ACTION.KICK: {
+        if (!targetMember) {
+          throw new Error('Target member missing for kick');
+        }
+        await targetMember.kick(auditReason);
+        break;
+      }
+      case ACTION.WARN: {
+        // no external action, only persistence
+        break;
+      }
+      default:
+        throw new Error(`Unsupported action: ${actionType}`);
+    }
+  } catch (error) {
+    await markCaseFailed(caseId);
+    embed
+      .setColor(ERROR_COLOR)
+      .setDescription(
+        language === 'de'
+          ? 'Die Moderationsaktion ist fehlgeschlagen.'
+          : 'The moderation action failed.'
+      );
+    result.ok = false;
+    result.embed = embed;
+    result.error = error;
+    return result;
+  }
+
+  const statusPayload = {
+    startTs,
+    endTs: durationInfo.endTs ?? null,
+    permanent: durationInfo.permanent,
+  };
+
+  await updateCaseStatus(caseId, STATUS.ACTIVE, statusPayload);
+
+  const auditId = await attachAuditInfo(guild, actionType, caseId);
+
+  embed
+    .setColor(SUCCESS_COLOR)
+    .setDescription(
+      language === 'de'
+        ? `Aktion erfolgreich abgeschlossen. Case #${caseId}`
+        : `Action completed successfully. Case #${caseId}`
+    );
+
+  await sendModLog(
+    guild,
+    {
+      actionType,
+      caseId,
+      target: targetMember?.user ?? targetUser ?? null,
+      targetId,
+      moderator: moderator.user ?? moderator,
+      startTs,
+      endTs: statusPayload.endTs,
+      permanent: statusPayload.permanent,
+      reasonText,
+      dmOk,
+      auditId,
+      color: SUCCESS_COLOR,
+    },
+    language
+  );
+
+  result.embed = embed;
+  return result;
+}
+
+export async function setPendingReasons(caseId, reasonCodes) {
+  return updateCaseReasonCodes(caseId, reasonCodes);
+}
+
+export async function setPendingCustomReason(caseId, text) {
+  return updateCaseCustomReason(caseId, text);
+}

--- a/src/modules/moderation/service/log.js
+++ b/src/modules/moderation/service/log.js
@@ -1,0 +1,116 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import { coreEmbed } from '../../../util/embeds/core.js';
+import { MOD_LOG_CHANNEL_ID } from '../config.js';
+
+const DM_STATUS = {
+  en: {
+    true: 'Delivered',
+    false: 'Failed',
+  },
+  de: {
+    true: 'Zugestellt',
+    false: 'Fehlgeschlagen',
+  },
+};
+
+export async function sendModLog(guild, data, lang = 'en') {
+  if (!guild) return false;
+  const language = lang === 'de' ? 'de' : 'en';
+  const channel = await guild.channels.fetch(MOD_LOG_CHANNEL_ID).catch(() => null);
+  if (!channel || !channel.isTextBased()) {
+    return false;
+  }
+
+  const embed = coreEmbed('LOGS', language);
+  if (data.color) {
+    embed.setColor(data.color);
+  }
+
+  const startUnix = data.startTs ? Math.floor(data.startTs.getTime() / 1000) : null;
+  const endUnix = data.endTs ? Math.floor(data.endTs.getTime() / 1000) : null;
+
+  const userField = {
+    name: language === 'de' ? 'Mitglied' : 'User',
+    value: data.target
+      ? `${data.target.tag ? `${data.target.tag}\n` : ''}<@${data.target.id}> (${data.target.id})`
+      : data.targetId
+        ? `<@${data.targetId}> (${data.targetId})`
+        : 'Unknown',
+    inline: false,
+  };
+
+  const moderatorField = {
+    name: language === 'de' ? 'Moderator' : 'Moderator',
+    value: data.moderator
+      ? `${data.moderator.tag ? `${data.moderator.tag}\n` : ''}<@${data.moderator.id}> (${data.moderator.id})`
+      : 'Unknown',
+    inline: false,
+  };
+
+  const dmKey = String(Boolean(data.dmOk));
+  const dmText = DM_STATUS[language]?.[dmKey] ?? (language === 'de' ? 'Fehlgeschlagen' : 'Failed');
+
+  embed
+    .setTitle(`${data.actionType} • Case #${data.caseId}`)
+    .addFields(
+      userField,
+      moderatorField,
+      startUnix
+        ? {
+            name: language === 'de' ? 'Start' : 'Start',
+            value: `<t:${startUnix}:F> • <t:${startUnix}:R>`,
+            inline: true,
+          }
+        : {
+            name: language === 'de' ? 'Start' : 'Start',
+            value: '—',
+            inline: true,
+          },
+      data.permanent
+        ? {
+            name: language === 'de' ? 'Dauer' : 'Duration',
+            value: language === 'de' ? 'Permanent' : 'Permanent',
+            inline: true,
+          }
+        : endUnix
+          ? {
+              name: language === 'de' ? 'Ende' : 'End',
+              value: `<t:${endUnix}:F> • <t:${endUnix}:R>`,
+              inline: true,
+            }
+          : {
+              name: language === 'de' ? 'Ende' : 'End',
+              value: '—',
+              inline: true,
+            },
+      {
+        name: language === 'de' ? 'Grund' : 'Reason',
+        value: data.reasonText || '—',
+        inline: false,
+      },
+      {
+        name: language === 'de' ? 'DM' : 'DM',
+        value: dmText,
+        inline: true,
+      },
+      {
+        name: 'Audit',
+        value: data.auditId ? data.auditId : '—',
+        inline: true,
+      }
+    );
+
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setLabel(language === 'de' ? 'Profil öffnen' : 'Open Profile')
+      .setStyle(ButtonStyle.Link)
+      .setURL(`https://discord.com/users/${data.target?.id ?? data.targetId}`)
+  );
+
+  try {
+    await channel.send({ embeds: [embed], components: [row] });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/modules/moderation/storage/repo.js
+++ b/src/modules/moderation/storage/repo.js
@@ -1,0 +1,196 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Pool } from 'pg';
+import { logger } from '../../../util/logging/logger.js';
+import { STATUS } from '../constants.js';
+
+const repoLogger = logger.withPrefix('moderation:repo');
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error('DATABASE_URL missing for moderation repository');
+}
+
+const pool = new Pool({ connectionString });
+
+const schemaPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'schema.sql');
+
+const initialisePromise = (async () => {
+  const sql = await readFile(schemaPath, 'utf8');
+  await pool.query(sql);
+  repoLogger.info('Schema initialised.');
+})();
+
+async function ready() {
+  await initialisePromise;
+}
+
+export async function createCase({
+  id,
+  guildId,
+  userId,
+  moderatorId,
+  actionType,
+  reasonCodes = [],
+  customReason = null,
+}) {
+  await ready();
+  const result = await pool.query(
+    `INSERT INTO moderation_actions (id, guild_id, user_id, moderator_id, action_type, reason_codes, custom_reason)
+     VALUES ($1, $2, $3, $4, $5, $6::text[], $7)
+     RETURNING *`,
+    [id, guildId, userId, moderatorId, actionType, reasonCodes, customReason]
+  );
+  return mapRow(result.rows[0]);
+}
+
+export async function getCaseById(id) {
+  await ready();
+  const result = await pool.query('SELECT * FROM moderation_actions WHERE id = $1', [id]);
+  return result.rows[0] ? mapRow(result.rows[0]) : null;
+}
+
+export async function updateCaseDuration(id, { endTs, permanent }) {
+  await ready();
+  const result = await pool.query(
+    `UPDATE moderation_actions
+     SET end_ts = $2, permanent = $3, updated_at = NOW()
+     WHERE id = $1
+     RETURNING *`,
+    [id, endTs, permanent]
+  );
+  return result.rows[0] ? mapRow(result.rows[0]) : null;
+}
+
+export async function updateCaseReasonCodes(id, reasonCodes) {
+  await ready();
+  const result = await pool.query(
+    `UPDATE moderation_actions
+     SET reason_codes = $2::text[], updated_at = NOW()
+     WHERE id = $1
+     RETURNING *`,
+    [id, reasonCodes]
+  );
+  return result.rows[0] ? mapRow(result.rows[0]) : null;
+}
+
+export async function updateCaseCustomReason(id, customReason) {
+  await ready();
+  const result = await pool.query(
+    `UPDATE moderation_actions
+     SET custom_reason = $2, updated_at = NOW()
+     WHERE id = $1
+     RETURNING *`,
+    [id, customReason]
+  );
+  return result.rows[0] ? mapRow(result.rows[0]) : null;
+}
+
+export async function updateCaseReasonText(id, reasonText) {
+  await ready();
+  const result = await pool.query(
+    `UPDATE moderation_actions
+     SET reason_text = $2, updated_at = NOW()
+     WHERE id = $1
+     RETURNING *`,
+    [id, reasonText]
+  );
+  return result.rows[0] ? mapRow(result.rows[0]) : null;
+}
+
+export async function updateCaseStatus(id, status, { startTs, endTs, permanent } = {}) {
+  await ready();
+  const result = await pool.query(
+    `UPDATE moderation_actions
+     SET status = $2,
+         start_ts = COALESCE($3, start_ts),
+         end_ts = COALESCE($4, end_ts),
+         permanent = COALESCE($5, permanent),
+         updated_at = NOW()
+     WHERE id = $1
+     RETURNING *`,
+    [id, status, startTs, endTs, permanent]
+  );
+  return result.rows[0] ? mapRow(result.rows[0]) : null;
+}
+
+export async function updateCaseDM(id, dmOk) {
+  await ready();
+  await pool.query(
+    `UPDATE moderation_actions
+     SET dm_ok = $2, updated_at = NOW()
+     WHERE id = $1`,
+    [id, dmOk]
+  );
+}
+
+export async function updateCaseAudit(id, auditId) {
+  await ready();
+  await pool.query(
+    `UPDATE moderation_actions
+     SET audit_id = $2, updated_at = NOW()
+     WHERE id = $1`,
+    [id, auditId]
+  );
+}
+
+export async function markCaseFailed(id) {
+  await ready();
+  await pool.query(
+    `UPDATE moderation_actions
+     SET status = $2, updated_at = NOW()
+     WHERE id = $1`,
+    [id, STATUS.FAILED]
+  );
+}
+
+export async function findDueToLift(limit = 20) {
+  await ready();
+  const result = await pool.query(
+    `SELECT * FROM moderation_actions
+     WHERE status = $1
+       AND end_ts IS NOT NULL
+       AND end_ts <= NOW()
+     ORDER BY end_ts ASC
+     LIMIT $2`,
+    [STATUS.ACTIVE, limit]
+  );
+  return result.rows.map(mapRow);
+}
+
+export async function markLifted(id) {
+  await ready();
+  await pool.query(
+    `UPDATE moderation_actions
+     SET status = $2, updated_at = NOW()
+     WHERE id = $1`,
+    [id, STATUS.LIFTED]
+  );
+}
+
+export async function closePool() {
+  await pool.end();
+}
+
+function mapRow(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    guildId: row.guild_id,
+    userId: row.user_id,
+    moderatorId: row.moderator_id,
+    actionType: row.action_type,
+    reasonCodes: row.reason_codes ?? [],
+    reasonText: row.reason_text ?? null,
+    customReason: row.custom_reason ?? null,
+    startTs: row.start_ts ? new Date(row.start_ts) : null,
+    endTs: row.end_ts ? new Date(row.end_ts) : null,
+    permanent: Boolean(row.permanent),
+    auditId: row.audit_id ?? null,
+    dmOk: Boolean(row.dm_ok),
+    status: row.status,
+    createdAt: row.created_at ? new Date(row.created_at) : null,
+    updatedAt: row.updated_at ? new Date(row.updated_at) : null,
+  };
+}

--- a/src/modules/moderation/storage/schema.sql
+++ b/src/modules/moderation/storage/schema.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS moderation_actions (
+  id UUID PRIMARY KEY,
+  guild_id VARCHAR(32) NOT NULL,
+  user_id VARCHAR(32) NOT NULL,
+  moderator_id VARCHAR(32) NOT NULL,
+  action_type VARCHAR(16) NOT NULL,
+  reason_codes TEXT[] DEFAULT ARRAY[]::TEXT[] NOT NULL,
+  reason_text TEXT,
+  custom_reason TEXT,
+  start_ts TIMESTAMP,
+  end_ts TIMESTAMP,
+  permanent BOOLEAN DEFAULT FALSE NOT NULL,
+  audit_id VARCHAR(128),
+  dm_ok BOOLEAN DEFAULT FALSE NOT NULL,
+  status VARCHAR(16) DEFAULT 'PENDING'::VARCHAR NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMP DEFAULT NOW() NOT NULL
+);

--- a/src/modules/moderation/ui/confirmButtons.js
+++ b/src/modules/moderation/ui/confirmButtons.js
@@ -1,0 +1,159 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ComponentType,
+  StringSelectMenuBuilder,
+} from 'discord.js';
+import { coreEmbed } from '../../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../../util/embeds/lang.js';
+import { CUSTOM_IDS, CONFIRM_ACTION, ERROR_COLOR, STATUS } from '../constants.js';
+import { executeAction } from '../service/exec.js';
+import { getCaseById, markCaseFailed } from '../storage/repo.js';
+
+function encodeCustomId(actionType, caseId, decision) {
+  return `${CUSTOM_IDS.CONFIRM_BUTTON}:${actionType}:${caseId}:${decision}`;
+}
+
+function parseCustomId(customId) {
+  const [, actionType, caseId, decision] = customId.split(':');
+  return { actionType, caseId, decision };
+}
+
+export function buildConfirmButtons(actionType, caseId, lang = 'en') {
+  const language = lang === 'de' ? 'de' : 'en';
+  return new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(encodeCustomId(actionType, caseId, CONFIRM_ACTION.CONFIRM))
+      .setLabel(language === 'de' ? 'Bestätigen' : 'Confirm')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(encodeCustomId(actionType, caseId, CONFIRM_ACTION.CANCEL))
+      .setLabel(language === 'de' ? 'Abbrechen' : 'Cancel')
+      .setStyle(ButtonStyle.Secondary)
+  );
+}
+
+export function isConfirmButton(interaction) {
+  return interaction.isButton() && interaction.customId.startsWith(`${CUSTOM_IDS.CONFIRM_BUTTON}:`);
+}
+
+function disableComponents(rows) {
+  return rows.map((row) => {
+    const builder = new ActionRowBuilder();
+    for (const component of row.components) {
+      if (component.type === ComponentType.Button) {
+        const button = ButtonBuilder.from(component);
+        builder.addComponents(button.setDisabled(true));
+      } else if (component.type === ComponentType.StringSelect) {
+        const select = StringSelectMenuBuilder.from(component);
+        builder.addComponents(select.setDisabled(true));
+      }
+    }
+    return builder;
+  });
+}
+
+export async function handleConfirmButton(interaction) {
+  const { actionType, caseId, decision } = parseCustomId(interaction.customId);
+  const lang = detectLangFromInteraction(interaction);
+
+  if (!caseId) {
+    const embed = coreEmbed('ANN', lang).setColor(ERROR_COLOR).setDescription(
+      lang === 'de' ? 'Fall-ID fehlt.' : 'Missing case id.'
+    );
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  if (![CONFIRM_ACTION.CONFIRM, CONFIRM_ACTION.CANCEL].includes(decision)) {
+    const embed = coreEmbed('ANN', lang).setColor(ERROR_COLOR).setDescription(
+      lang === 'de' ? 'Unbekannte Aktion.' : 'Unknown action.'
+    );
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  const caseRecord = await getCaseById(caseId);
+  if (!caseRecord) {
+    const embed = coreEmbed('ANN', lang).setColor(ERROR_COLOR).setDescription(
+      lang === 'de' ? 'Fall nicht gefunden.' : 'Case not found.'
+    );
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  if (caseRecord.status !== STATUS.PENDING) {
+    const embed = coreEmbed('ANN', lang).setColor(ERROR_COLOR).setDescription(
+      lang === 'de' ? 'Dieser Fall wurde bereits bearbeitet.' : 'This case has already been processed.'
+    );
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  if (decision === CONFIRM_ACTION.CANCEL) {
+    await interaction.deferReply({ ephemeral: true });
+    await markCaseFailed(caseId);
+    const disabled = disableComponents(interaction.message.components);
+    await interaction.message.edit({ components: disabled });
+    const embed = coreEmbed('ANN', lang)
+      .setColor(ERROR_COLOR)
+      .setDescription(lang === 'de' ? 'Fall verworfen.' : 'Case cancelled.');
+    await interaction.editReply({ embeds: [embed] });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const guild = interaction.guild;
+  if (!guild) {
+    const embed = coreEmbed('ANN', lang)
+      .setColor(ERROR_COLOR)
+      .setDescription(
+        lang === 'de' ? 'Keine Guild verfügbar.' : 'Guild unavailable.'
+      );
+    await interaction.editReply({ embeds: [embed] });
+    return;
+  }
+
+  const targetMember = await guild.members.fetch(caseRecord.userId).catch(() => null);
+  const targetUser = targetMember?.user ?? (await guild.client.users.fetch(caseRecord.userId).catch(() => null));
+
+  let result;
+  try {
+    result = await executeAction({
+      interaction,
+      caseId,
+      actionType: actionType ?? caseRecord.actionType,
+      guild,
+      moderator: interaction.member,
+      targetMember,
+      targetUser,
+      reasonCodes: caseRecord.reasonCodes,
+      customReason: caseRecord.customReason,
+      lang,
+    });
+  } catch (error) {
+    const errorEmbed = coreEmbed('ANN', lang)
+      .setColor(ERROR_COLOR)
+      .setDescription(lang === 'de' ? 'Aktion fehlgeschlagen.' : 'Action failed.');
+    await interaction.editReply({ embeds: [errorEmbed] });
+    return;
+  }
+
+  if (!result.ok) {
+    const fresh = await getCaseById(caseId);
+    if (fresh && fresh.status !== STATUS.PENDING) {
+      const disabled = disableComponents(interaction.message.components);
+      await interaction.message.edit({ components: disabled });
+    }
+    await interaction.editReply({ embeds: [result.embed] });
+    return;
+  }
+
+  const disabled = disableComponents(interaction.message.components);
+  await interaction.message.edit({ components: disabled });
+  await interaction.editReply({ embeds: [result.embed] });
+}
+
+export { encodeCustomId as buildConfirmCustomId };

--- a/src/modules/moderation/ui/customReasonModal.js
+++ b/src/modules/moderation/ui/customReasonModal.js
@@ -1,0 +1,81 @@
+import {
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  ActionRowBuilder,
+} from 'discord.js';
+import { coreEmbed } from '../../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../../util/embeds/lang.js';
+import { CUSTOM_IDS, ERROR_COLOR, SUCCESS_COLOR, STATUS } from '../constants.js';
+import { setPendingCustomReason } from '../service/exec.js';
+import { getCaseById } from '../storage/repo.js';
+
+const INPUT_ID = 'custom_reason_text';
+
+function encodeCustomId(caseId) {
+  return `${CUSTOM_IDS.REASON_MODAL}:${caseId}`;
+}
+
+function parseCustomId(customId) {
+  const [, caseId] = customId.split(':');
+  return caseId;
+}
+
+export function buildCustomReasonModal(caseId, lang = 'en') {
+  const language = lang === 'de' ? 'de' : 'en';
+  return new ModalBuilder()
+    .setCustomId(encodeCustomId(caseId))
+    .setTitle(language === 'de' ? 'Eigener Grund' : 'Custom reason')
+    .addComponents(
+      new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId(INPUT_ID)
+          .setLabel(language === 'de' ? 'Bitte beschreibe den Grund' : 'Describe the reason')
+          .setStyle(TextInputStyle.Paragraph)
+          .setRequired(true)
+          .setMaxLength(512)
+      )
+    );
+}
+
+export function isCustomReasonModal(interaction) {
+  return interaction.isModalSubmit() && interaction.customId.startsWith(`${CUSTOM_IDS.REASON_MODAL}:`);
+}
+
+export async function handleCustomReasonModal(interaction) {
+  const caseId = parseCustomId(interaction.customId);
+  const lang = detectLangFromInteraction(interaction);
+  const embed = coreEmbed('ANN', lang);
+
+  if (!caseId) {
+    embed.setColor(ERROR_COLOR).setDescription(lang === 'de' ? 'Fall-ID fehlt.' : 'Missing case id.');
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  const caseRecord = await getCaseById(caseId);
+  if (!caseRecord || caseRecord.status !== STATUS.PENDING) {
+    embed.setColor(ERROR_COLOR).setDescription(
+      lang === 'de' ? 'Dieser Fall wurde bereits bearbeitet.' : 'This case has already been processed.'
+    );
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  const value = interaction.fields.getTextInputValue(INPUT_ID)?.trim();
+  if (!value) {
+    embed.setColor(ERROR_COLOR).setDescription(lang === 'de' ? 'Bitte gib einen Grund ein.' : 'Please provide a reason.');
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  await setPendingCustomReason(caseId, value);
+
+  embed
+    .setColor(SUCCESS_COLOR)
+    .setDescription(lang === 'de' ? 'Eigener Grund gespeichert.' : 'Custom reason saved.');
+
+  await interaction.reply({ ephemeral: true, embeds: [embed] });
+}
+
+export { encodeCustomId as buildCustomReasonCustomId };

--- a/src/modules/moderation/ui/durationSelect.js
+++ b/src/modules/moderation/ui/durationSelect.js
@@ -1,0 +1,127 @@
+import {
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuOptionBuilder,
+} from 'discord.js';
+import { coreEmbed } from '../../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../../util/embeds/lang.js';
+import { BAN_PRESETS, TIMEOUT_PRESETS } from '../config.js';
+import { ACTION, CUSTOM_IDS, ERROR_COLOR, SUCCESS_COLOR } from '../constants.js';
+import { getCaseById, updateCaseDuration } from '../storage/repo.js';
+
+const DURATION_MAP = {
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+};
+
+function encodeCustomId(actionType, caseId) {
+  return `${CUSTOM_IDS.DURATION_SELECT}:${actionType}:${caseId}`;
+}
+
+function parseCustomId(customId) {
+  const [, actionType, caseId] = customId.split(':');
+  return { actionType, caseId };
+}
+
+function presetToMs(value) {
+  if (!value) return null;
+  if (value === 'permanent') return null;
+  const match = /^([0-9]+)([mhd])$/.exec(value);
+  if (!match) return null;
+  const [, amount, unit] = match;
+  const factor = DURATION_MAP[unit];
+  return factor ? Number(amount) * factor : null;
+}
+
+export function buildDurationSelect(actionType, caseId, lang = 'en') {
+  const language = lang === 'de' ? 'de' : 'en';
+  const presets = actionType === ACTION.BAN ? BAN_PRESETS : TIMEOUT_PRESETS;
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(encodeCustomId(actionType, caseId))
+    .setPlaceholder(language === 'de' ? 'Dauer wählen' : 'Select duration')
+    .setMinValues(1)
+    .setMaxValues(1);
+
+  for (const preset of presets) {
+    const label = preset === 'permanent'
+      ? language === 'de'
+        ? 'Permanent'
+        : 'Permanent'
+      : preset;
+    select.addOptions(
+      new StringSelectMenuOptionBuilder()
+        .setLabel(label)
+        .setValue(preset)
+    );
+  }
+
+  return new ActionRowBuilder().addComponents(select);
+}
+
+export function isDurationSelect(interaction) {
+  return interaction.isStringSelectMenu() && interaction.customId.startsWith(`${CUSTOM_IDS.DURATION_SELECT}:`);
+}
+
+export async function handleDurationSelect(interaction) {
+  const { actionType, caseId } = parseCustomId(interaction.customId);
+  const lang = detectLangFromInteraction(interaction);
+  const embed = coreEmbed('ANN', lang);
+
+  const value = interaction.values?.[0];
+  if (!caseId || !value) {
+    embed.setColor(ERROR_COLOR).setDescription(
+      lang === 'de' ? 'Ungültige Auswahl.' : 'Invalid selection.'
+    );
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  const caseRecord = await getCaseById(caseId);
+  if (!caseRecord) {
+    embed.setColor(ERROR_COLOR).setDescription(
+      lang === 'de' ? 'Der Fall wurde nicht gefunden.' : 'The case could not be found.'
+    );
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  if (caseRecord.actionType !== actionType) {
+    embed.setColor(ERROR_COLOR).setDescription(
+      lang === 'de' ? 'Aktion passt nicht zum Fall.' : 'Action type does not match this case.'
+    );
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  let endTs = null;
+  let permanent = false;
+
+  if (value === 'permanent') {
+    permanent = true;
+  } else {
+    const durationMs = presetToMs(value);
+    if (!durationMs || !caseRecord.createdAt) {
+      embed.setColor(ERROR_COLOR).setDescription(
+        lang === 'de' ? 'Die Dauer konnte nicht verarbeitet werden.' : 'The duration could not be processed.'
+      );
+      await interaction.reply({ ephemeral: true, embeds: [embed] });
+      return;
+    }
+    endTs = new Date(caseRecord.createdAt.getTime() + durationMs);
+  }
+
+  await updateCaseDuration(caseId, { endTs, permanent });
+
+  embed
+    .setColor(SUCCESS_COLOR)
+    .setDescription(
+      lang === 'de'
+        ? `Dauer gesetzt: ${value === 'permanent' ? 'Permanent' : value}`
+        : `Duration set: ${value === 'permanent' ? 'Permanent' : value}`
+    );
+
+  await interaction.reply({ ephemeral: true, embeds: [embed] });
+}
+
+export { encodeCustomId as buildDurationCustomId };

--- a/src/modules/moderation/ui/reasonsSelect.js
+++ b/src/modules/moderation/ui/reasonsSelect.js
@@ -1,0 +1,96 @@
+import {
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuOptionBuilder,
+} from 'discord.js';
+import { coreEmbed } from '../../../util/embeds/core.js';
+import { detectLangFromInteraction } from '../../../util/embeds/lang.js';
+import { REASON_CODES, REASON_LABELS } from '../config.js';
+import { CUSTOM_IDS, ERROR_COLOR, SUCCESS_COLOR, STATUS } from '../constants.js';
+import { getCaseById } from '../storage/repo.js';
+import { setPendingReasons, setPendingCustomReason } from '../service/exec.js';
+import { buildCustomReasonModal } from './customReasonModal.js';
+
+function encodeCustomId(caseId) {
+  return `${CUSTOM_IDS.REASON_SELECT}:${caseId}`;
+}
+
+function parseCustomId(customId) {
+  const [, caseId] = customId.split(':');
+  return caseId;
+}
+
+export function buildReasonsSelect(caseId, lang = 'en') {
+  const language = lang === 'de' ? 'de' : 'en';
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(encodeCustomId(caseId))
+    .setPlaceholder(language === 'de' ? 'Gründe auswählen' : 'Select reasons')
+    .setMinValues(1)
+    .setMaxValues(3);
+
+  for (const code of REASON_CODES) {
+    const label = REASON_LABELS[language][code] ?? code;
+    select.addOptions(new StringSelectMenuOptionBuilder().setLabel(label).setValue(code));
+  }
+
+  return new ActionRowBuilder().addComponents(select);
+}
+
+export function isReasonsSelect(interaction) {
+  return interaction.isStringSelectMenu() && interaction.customId.startsWith(`${CUSTOM_IDS.REASON_SELECT}:`);
+}
+
+export async function handleReasonsSelect(interaction) {
+  const caseId = parseCustomId(interaction.customId);
+  const lang = detectLangFromInteraction(interaction);
+  const embed = coreEmbed('ANN', lang);
+
+  if (!caseId) {
+    embed.setColor(ERROR_COLOR).setDescription(lang === 'de' ? 'Der Fall fehlt.' : 'Missing case identifier.');
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  const caseRecord = await getCaseById(caseId);
+  if (!caseRecord) {
+    embed.setColor(ERROR_COLOR).setDescription(lang === 'de' ? 'Fall nicht gefunden.' : 'Case not found.');
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  if (caseRecord.status !== STATUS.PENDING) {
+    embed.setColor(ERROR_COLOR).setDescription(
+      lang === 'de' ? 'Dieser Fall wurde bereits bearbeitet.' : 'This case has already been processed.'
+    );
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  const values = interaction.values ?? [];
+  if (!values.length) {
+    embed.setColor(ERROR_COLOR).setDescription(lang === 'de' ? 'Mindestens ein Grund ist nötig.' : 'Select at least one reason.');
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  await setPendingReasons(caseId, values);
+
+  if (!values.includes('CUSTOM')) {
+    await setPendingCustomReason(caseId, null);
+    const labelMap = REASON_LABELS[language] ?? {};
+    embed
+      .setColor(SUCCESS_COLOR)
+      .setDescription(
+        language === 'de'
+          ? `Gründe gespeichert: ${values.map((code) => labelMap[code] ?? code).join(', ')}`
+          : `Reasons saved: ${values.map((code) => labelMap[code] ?? code).join(', ')}`
+      );
+    await interaction.reply({ ephemeral: true, embeds: [embed] });
+    return;
+  }
+
+  const modal = buildCustomReasonModal(caseId, lang);
+  await interaction.showModal(modal);
+}
+
+export { encodeCustomId as buildReasonCustomId };

--- a/src/modules/moderation/worker/scheduler.js
+++ b/src/modules/moderation/worker/scheduler.js
@@ -1,0 +1,107 @@
+import { logger } from '../../../util/logging/logger.js';
+import { ACTION, SUCCESS_COLOR } from '../constants.js';
+import { findDueToLift, markLifted } from '../storage/repo.js';
+import { sendModLog } from '../service/log.js';
+
+const workerLogger = logger.withPrefix('moderation:worker');
+const INTERVAL_MS = 3 * 60 * 1000;
+let intervalHandle;
+
+function detectLanguageFromGuild(guild) {
+  const locale = guild?.preferredLocale ?? 'en';
+  return typeof locale === 'string' && locale.toLowerCase().startsWith('de') ? 'de' : 'en';
+}
+
+async function processCase(client, guild, entry) {
+  const lang = detectLanguageFromGuild(guild);
+  let lifted = false;
+  const reason = lang === 'de' ? `Automatisch aufgehoben (Case #${entry.id}).` : `Automatically lifted (Case #${entry.id}).`;
+
+  try {
+    if (entry.actionType === ACTION.TIMEOUT) {
+      const member = await guild.members.fetch(entry.userId).catch(() => null);
+      if (member) {
+        await member.timeout(null, reason);
+        lifted = true;
+      }
+    } else if (entry.actionType === ACTION.BAN) {
+      try {
+        await guild.members.unban(entry.userId, reason);
+        lifted = true;
+      } catch (err) {
+        if (err?.code === 10026) {
+          lifted = true;
+        } else {
+          workerLogger.warn('Unban im Worker fehlgeschlagen:', err);
+        }
+      }
+    }
+  } catch (error) {
+    workerLogger.warn('Fehler beim Aufheben:', error);
+  }
+
+  if (!lifted) {
+    return;
+  }
+
+  await markLifted(entry.id);
+
+  const targetUser = await client.users.fetch(entry.userId).catch(() => null);
+  const moderator = guild.members.me?.user ?? client.user;
+
+  await sendModLog(
+    guild,
+    {
+      actionType: `${entry.actionType}_LIFT`,
+      caseId: entry.id,
+      target: targetUser,
+      targetId: entry.userId,
+      moderator,
+      startTs: entry.startTs ?? new Date(),
+      endTs: entry.endTs ?? new Date(),
+      permanent: false,
+      reasonText:
+        lang === 'de'
+          ? 'Maßnahme automatisch aufgehoben (Dauer abgelaufen).'
+          : 'Action lifted automatically (duration expired).',
+      dmOk: entry.dmOk,
+      auditId: entry.auditId,
+      color: SUCCESS_COLOR,
+    },
+    lang
+  );
+}
+
+async function runCycle(client) {
+  const entries = await findDueToLift();
+  if (!entries.length) {
+    return;
+  }
+
+  for (const entry of entries) {
+    const guild = await client.guilds.fetch(entry.guildId).catch(() => null);
+    if (!guild) {
+      workerLogger.warn('Guild nicht erreichbar für Case', entry.id);
+      continue;
+    }
+    await processCase(client, guild, entry);
+  }
+}
+
+export function startModerationScheduler(client) {
+  if (intervalHandle) {
+    return;
+  }
+  intervalHandle = setInterval(() => {
+    runCycle(client).catch((error) => workerLogger.error('Worker-Fehler:', error));
+  }, INTERVAL_MS);
+  intervalHandle.unref?.();
+  runCycle(client).catch((error) => workerLogger.error('Worker-Fehler:', error));
+}
+
+export function stopModerationScheduler() {
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- add moderation configuration, constants, Postgres repository, service layer, and scheduler for lifting temporary actions
- implement /ban, /timeout, /kick, /warn, and /unban commands with guided UI for durations, reasons, custom notes, and confirmation
- wire moderation interaction handlers and start the scheduler on ready to support DM-first enforcement, team gating, and mod logging

## Testing
- npm test *(fails: vitest binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d06fab84832d84ac3ce680f9b4b7