### PR TITLE
Stabilize moderation flows and command guards

### DIFF
--- a/src/commands/ban/command.js
+++ b/src/commands/ban/command.js
@@ -1,13 +1,13 @@
-import { ApplicationCommandOptionType } from 'discord.js';
+import { ApplicationCommandOptionType, MessageFlags, PermissionsBitField } from 'discord.js';
 import { randomUUID } from 'node:crypto';
 import { coreEmbed } from '../../util/embeds/core.js';
 import { detectLangFromInteraction } from '../../util/embeds/lang.js';
-import { TEAM_ROLE_ID } from '../../modules/moderation/config.js';
 import { ACTION, ERROR_COLOR } from '../../modules/moderation/constants.js';
 import { createCase } from '../../modules/moderation/storage/repo.js';
 import { buildDurationSelect } from '../../modules/moderation/ui/durationSelect.js';
 import { buildReasonsSelect } from '../../modules/moderation/ui/reasonsSelect.js';
 import { buildConfirmButtons } from '../../modules/moderation/ui/confirmButtons.js';
+import { compareBotHierarchy, compareHierarchy, hasTeamRole } from '../../modules/moderation/service/exec.js';
 
 export default {
   name: 'ban',
@@ -26,23 +26,83 @@ export default {
       return;
     }
 
-    const lang = detectLangFromInteraction(interaction);
+    const lang = detectLangFromInteraction(interaction) ?? 'en';
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
     const embed = coreEmbed('ANN', lang);
 
-    if (!interaction.member?.roles?.cache?.has(TEAM_ROLE_ID)) {
+    if (!hasTeamRole(interaction.member)) {
       embed
         .setColor(ERROR_COLOR)
-        .setDescription(lang === 'de' ? 'Du benötigst die Team-Rolle.' : 'You need the team role.');
-      await interaction.reply({ ephemeral: true, embeds: [embed] });
+        .setDescription(lang === 'de' ? 'Keine Berechtigung (Team-Rolle erforderlich).' : 'Missing permission (team role required).');
+      await interaction.editReply({ embeds: [embed], components: [] });
       return;
     }
 
-    const target = interaction.options.getUser('target', true);
+    if (!interaction.member.permissions?.has(PermissionsBitField.Flags.BanMembers)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Dir fehlt die Berechtigung BAN_MEMBERS.' : 'You lack the BAN_MEMBERS permission.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    const targetUser = interaction.options.getUser('target', true);
+    if (!targetUser) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Ziel konnte nicht gelesen werden.' : 'Target user unavailable.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetUser.id === interaction.user.id) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Du kannst dich nicht selbst bannen.' : 'You cannot ban yourself.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetUser.bot) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Bots können nicht gebannt werden.' : 'Bots cannot be banned.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    const targetMember = await interaction.guild.members.fetch(targetUser.id).catch(() => null);
+
+    if (hasTeamRole(targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Aktion blockiert: Ziel gehört zum Team.' : 'Action blocked: target is part of the team.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetMember && !compareHierarchy(interaction.member, targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Rollen-Hierarchie verhindert diese Aktion.' : 'Role hierarchy prevents this action.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetMember && !compareBotHierarchy(interaction.guild, targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Bot-Rolle nicht hoch genug.' : 'Bot role hierarchy too low.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
     const caseId = randomUUID();
     await createCase({
       id: caseId,
       guildId: interaction.guild.id,
-      userId: target.id,
+      userId: targetUser.id,
       moderatorId: interaction.user.id,
       actionType: ACTION.BAN,
     });
@@ -54,16 +114,15 @@ export default {
     embed
       .setDescription(
         lang === 'de'
-          ? `Bitte konfiguriere den Bann für <@${target.id}> (Case #${caseId}).`
-          : `Configure the ban for <@${target.id}> (Case #${caseId}).`
+          ? `Bitte konfiguriere den Bann für <@${targetUser.id}> (Case #${caseId}).`
+          : `Configure the ban for <@${targetUser.id}> (Case #${caseId}).`
       )
       .addFields({
         name: lang === 'de' ? 'Ziel' : 'Target',
-        value: `<@${target.id}> (${target.tag ?? target.id})`,
+        value: `<@${targetUser.id}> (${targetUser.tag ?? targetUser.id})`,
       });
 
-    await interaction.reply({
-      ephemeral: true,
+    await interaction.editReply({
       embeds: [embed],
       components: [durationRow, reasonRow, confirmRow],
     });

--- a/src/commands/clear/command.js
+++ b/src/commands/clear/command.js
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType } from 'discord.js';
+import { ApplicationCommandOptionType, MessageFlags } from 'discord.js';
 import { coreEmbed } from '../../util/embeds/core.js';
 import { detectLangFromInteraction } from '../../util/embeds/lang.js';
 
@@ -25,11 +25,11 @@ export default {
         .setTitle('No Permission')
         .setDescription('You do not have permission to use this command.')
         .setColor(0xff0000);
-      await interaction.reply({ embeds: [embed], ephemeral: true, allowedMentions: { parse: [] } });
+      await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral, allowedMentions: { parse: [] } });
       return;
     }
 
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     let deleted = 0;
     try {

--- a/src/commands/kick/command.js
+++ b/src/commands/kick/command.js
@@ -1,12 +1,12 @@
-import { ApplicationCommandOptionType } from 'discord.js';
+import { ApplicationCommandOptionType, MessageFlags, PermissionsBitField } from 'discord.js';
 import { randomUUID } from 'node:crypto';
 import { coreEmbed } from '../../util/embeds/core.js';
 import { detectLangFromInteraction } from '../../util/embeds/lang.js';
-import { TEAM_ROLE_ID } from '../../modules/moderation/config.js';
 import { ACTION, ERROR_COLOR } from '../../modules/moderation/constants.js';
 import { createCase } from '../../modules/moderation/storage/repo.js';
 import { buildReasonsSelect } from '../../modules/moderation/ui/reasonsSelect.js';
 import { buildConfirmButtons } from '../../modules/moderation/ui/confirmButtons.js';
+import { compareBotHierarchy, compareHierarchy, hasTeamRole } from '../../modules/moderation/service/exec.js';
 
 export default {
   name: 'kick',
@@ -25,23 +25,83 @@ export default {
       return;
     }
 
-    const lang = detectLangFromInteraction(interaction);
+    const lang = detectLangFromInteraction(interaction) ?? 'en';
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
     const embed = coreEmbed('ANN', lang);
 
-    if (!interaction.member?.roles?.cache?.has(TEAM_ROLE_ID)) {
+    if (!hasTeamRole(interaction.member)) {
       embed
         .setColor(ERROR_COLOR)
-        .setDescription(lang === 'de' ? 'Du benötigst die Team-Rolle.' : 'You need the team role.');
-      await interaction.reply({ ephemeral: true, embeds: [embed] });
+        .setDescription(lang === 'de' ? 'Keine Berechtigung (Team-Rolle erforderlich).' : 'Missing permission (team role required).');
+      await interaction.editReply({ embeds: [embed], components: [] });
       return;
     }
 
-    const target = interaction.options.getUser('target', true);
+    if (!interaction.member.permissions?.has(PermissionsBitField.Flags.KickMembers)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Dir fehlt die Berechtigung KICK_MEMBERS.' : 'You lack the KICK_MEMBERS permission.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    const targetUser = interaction.options.getUser('target', true);
+    if (!targetUser) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Ziel konnte nicht gelesen werden.' : 'Target user unavailable.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetUser.id === interaction.user.id) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Du kannst dich nicht selbst kicken.' : 'You cannot kick yourself.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetUser.bot) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Bots können nicht gekickt werden.' : 'Bots cannot be kicked.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    const targetMember = await interaction.guild.members.fetch(targetUser.id).catch(() => null);
+
+    if (hasTeamRole(targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Aktion blockiert: Ziel gehört zum Team.' : 'Action blocked: target is part of the team.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetMember && !compareHierarchy(interaction.member, targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Rollen-Hierarchie verhindert diese Aktion.' : 'Role hierarchy prevents this action.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetMember && !compareBotHierarchy(interaction.guild, targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Bot-Rolle nicht hoch genug.' : 'Bot role hierarchy too low.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
     const caseId = randomUUID();
     await createCase({
       id: caseId,
       guildId: interaction.guild.id,
-      userId: target.id,
+      userId: targetUser.id,
       moderatorId: interaction.user.id,
       actionType: ACTION.KICK,
     });
@@ -52,16 +112,15 @@ export default {
     embed
       .setDescription(
         lang === 'de'
-          ? `Bitte bestätige den Kick für <@${target.id}> (Case #${caseId}).`
-          : `Configure the kick for <@${target.id}> (Case #${caseId}).`
+          ? `Bitte bestätige den Kick für <@${targetUser.id}> (Case #${caseId}).`
+          : `Configure the kick for <@${targetUser.id}> (Case #${caseId}).`
       )
       .addFields({
         name: lang === 'de' ? 'Ziel' : 'Target',
-        value: `<@${target.id}> (${target.tag ?? target.id})`,
+        value: `<@${targetUser.id}> (${targetUser.tag ?? targetUser.id})`,
       });
 
-    await interaction.reply({
-      ephemeral: true,
+    await interaction.editReply({
       embeds: [embed],
       components: [reasonRow, confirmRow],
     });

--- a/src/commands/ping/command.js
+++ b/src/commands/ping/command.js
@@ -9,7 +9,7 @@ export default {
   description: 'Show bot and API latency',
   async execute(interaction, client) {
     const start = Date.now();
-    await interaction.deferReply({ ephemeral: false });
+    await interaction.deferReply();
     const roundtrip = Date.now() - start;
 
     const uptimeMs = client.uptime ?? 0;

--- a/src/commands/timeout/command.js
+++ b/src/commands/timeout/command.js
@@ -1,13 +1,13 @@
-import { ApplicationCommandOptionType } from 'discord.js';
+import { ApplicationCommandOptionType, MessageFlags, PermissionsBitField } from 'discord.js';
 import { randomUUID } from 'node:crypto';
 import { coreEmbed } from '../../util/embeds/core.js';
 import { detectLangFromInteraction } from '../../util/embeds/lang.js';
-import { TEAM_ROLE_ID } from '../../modules/moderation/config.js';
 import { ACTION, ERROR_COLOR } from '../../modules/moderation/constants.js';
 import { createCase } from '../../modules/moderation/storage/repo.js';
 import { buildDurationSelect } from '../../modules/moderation/ui/durationSelect.js';
 import { buildReasonsSelect } from '../../modules/moderation/ui/reasonsSelect.js';
 import { buildConfirmButtons } from '../../modules/moderation/ui/confirmButtons.js';
+import { compareBotHierarchy, compareHierarchy, hasTeamRole } from '../../modules/moderation/service/exec.js';
 
 export default {
   name: 'timeout',
@@ -26,23 +26,83 @@ export default {
       return;
     }
 
-    const lang = detectLangFromInteraction(interaction);
+    const lang = detectLangFromInteraction(interaction) ?? 'en';
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
     const embed = coreEmbed('ANN', lang);
 
-    if (!interaction.member?.roles?.cache?.has(TEAM_ROLE_ID)) {
+    if (!hasTeamRole(interaction.member)) {
       embed
         .setColor(ERROR_COLOR)
-        .setDescription(lang === 'de' ? 'Du benötigst die Team-Rolle.' : 'You need the team role.');
-      await interaction.reply({ ephemeral: true, embeds: [embed] });
+        .setDescription(lang === 'de' ? 'Keine Berechtigung (Team-Rolle erforderlich).' : 'Missing permission (team role required).');
+      await interaction.editReply({ embeds: [embed], components: [] });
       return;
     }
 
-    const target = interaction.options.getUser('target', true);
+    if (!interaction.member.permissions?.has(PermissionsBitField.Flags.ModerateMembers)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Dir fehlt die Berechtigung MODERATE_MEMBERS.' : 'You lack the MODERATE_MEMBERS permission.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    const targetUser = interaction.options.getUser('target', true);
+    if (!targetUser) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Ziel konnte nicht gelesen werden.' : 'Target user unavailable.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetUser.id === interaction.user.id) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Du kannst dich nicht selbst timeouten.' : 'You cannot timeout yourself.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetUser.bot) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Bots können nicht getimeoutet werden.' : 'Bots cannot be timed out.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    const targetMember = await interaction.guild.members.fetch(targetUser.id).catch(() => null);
+
+    if (hasTeamRole(targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Aktion blockiert: Ziel gehört zum Team.' : 'Action blocked: target is part of the team.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetMember && !compareHierarchy(interaction.member, targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Rollen-Hierarchie verhindert diese Aktion.' : 'Role hierarchy prevents this action.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetMember && !compareBotHierarchy(interaction.guild, targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Bot-Rolle nicht hoch genug.' : 'Bot role hierarchy too low.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
     const caseId = randomUUID();
     await createCase({
       id: caseId,
       guildId: interaction.guild.id,
-      userId: target.id,
+      userId: targetUser.id,
       moderatorId: interaction.user.id,
       actionType: ACTION.TIMEOUT,
     });
@@ -54,16 +114,15 @@ export default {
     embed
       .setDescription(
         lang === 'de'
-          ? `Bitte konfiguriere den Timeout für <@${target.id}> (Case #${caseId}).`
-          : `Configure the timeout for <@${target.id}> (Case #${caseId}).`
+          ? `Bitte konfiguriere den Timeout für <@${targetUser.id}> (Case #${caseId}).`
+          : `Configure the timeout for <@${targetUser.id}> (Case #${caseId}).`
       )
       .addFields({
         name: lang === 'de' ? 'Ziel' : 'Target',
-        value: `<@${target.id}> (${target.tag ?? target.id})`,
+        value: `<@${targetUser.id}> (${targetUser.tag ?? targetUser.id})`,
       });
 
-    await interaction.reply({
-      ephemeral: true,
+    await interaction.editReply({
       embeds: [embed],
       components: [durationRow, reasonRow, confirmRow],
     });

--- a/src/commands/unban/command.js
+++ b/src/commands/unban/command.js
@@ -1,12 +1,12 @@
-import { ApplicationCommandOptionType } from 'discord.js';
+import { ApplicationCommandOptionType, MessageFlags, PermissionsBitField } from 'discord.js';
 import { randomUUID } from 'node:crypto';
 import { coreEmbed } from '../../util/embeds/core.js';
 import { detectLangFromInteraction } from '../../util/embeds/lang.js';
-import { TEAM_ROLE_ID } from '../../modules/moderation/config.js';
 import { ACTION, ERROR_COLOR } from '../../modules/moderation/constants.js';
 import { createCase } from '../../modules/moderation/storage/repo.js';
 import { buildReasonsSelect } from '../../modules/moderation/ui/reasonsSelect.js';
 import { buildConfirmButtons } from '../../modules/moderation/ui/confirmButtons.js';
+import { hasTeamRole } from '../../modules/moderation/service/exec.js';
 
 export default {
   name: 'unban',
@@ -25,23 +25,59 @@ export default {
       return;
     }
 
-    const lang = detectLangFromInteraction(interaction);
+    const lang = detectLangFromInteraction(interaction) ?? 'en';
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
     const embed = coreEmbed('ANN', lang);
 
-    if (!interaction.member?.roles?.cache?.has(TEAM_ROLE_ID)) {
+    if (!hasTeamRole(interaction.member)) {
       embed
         .setColor(ERROR_COLOR)
-        .setDescription(lang === 'de' ? 'Du benötigst die Team-Rolle.' : 'You need the team role.');
-      await interaction.reply({ ephemeral: true, embeds: [embed] });
+        .setDescription(lang === 'de' ? 'Keine Berechtigung (Team-Rolle erforderlich).' : 'Missing permission (team role required).');
+      await interaction.editReply({ embeds: [embed], components: [] });
       return;
     }
 
-    const userId = interaction.options.getString('user', true).replace(/[^0-9]/g, '');
+    if (!interaction.member.permissions?.has(PermissionsBitField.Flags.BanMembers)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Dir fehlt die Berechtigung BAN_MEMBERS.' : 'You lack the BAN_MEMBERS permission.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    const rawId = interaction.options.getString('user', true);
+    const userId = rawId.replace(/[^0-9]/g, '');
     if (!userId) {
       embed
         .setColor(ERROR_COLOR)
         .setDescription(lang === 'de' ? 'Bitte gib eine gültige ID an.' : 'Please provide a valid ID.');
-      await interaction.reply({ ephemeral: true, embeds: [embed] });
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (userId === interaction.user.id) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Du kannst dich nicht selbst entbannen.' : 'You cannot unban yourself.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (interaction.client.user && userId === interaction.client.user.id) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Der Bot kann nicht Ziel dieser Aktion sein.' : 'The bot cannot be targeted.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    const fetchedUser = await interaction.client.users.fetch(userId).catch(() => null);
+    if (fetchedUser?.bot) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Bots werden nicht automatisch entbannt.' : 'Bots cannot be unbanned with this command.');
+      await interaction.editReply({ embeds: [embed], components: [] });
       return;
     }
 
@@ -65,11 +101,10 @@ export default {
       )
       .addFields({
         name: lang === 'de' ? 'Ziel' : 'Target',
-        value: `<@${userId}> (${userId})`,
+        value: fetchedUser ? `<@${userId}> (${fetchedUser.tag ?? userId})` : `<@${userId}> (${userId})`,
       });
 
-    await interaction.reply({
-      ephemeral: true,
+    await interaction.editReply({
       embeds: [embed],
       components: [reasonRow, confirmRow],
     });

--- a/src/commands/warn/command.js
+++ b/src/commands/warn/command.js
@@ -1,12 +1,12 @@
-import { ApplicationCommandOptionType } from 'discord.js';
+import { ApplicationCommandOptionType, MessageFlags } from 'discord.js';
 import { randomUUID } from 'node:crypto';
 import { coreEmbed } from '../../util/embeds/core.js';
 import { detectLangFromInteraction } from '../../util/embeds/lang.js';
-import { TEAM_ROLE_ID } from '../../modules/moderation/config.js';
 import { ACTION, ERROR_COLOR } from '../../modules/moderation/constants.js';
 import { createCase } from '../../modules/moderation/storage/repo.js';
 import { buildReasonsSelect } from '../../modules/moderation/ui/reasonsSelect.js';
 import { buildConfirmButtons } from '../../modules/moderation/ui/confirmButtons.js';
+import { compareHierarchy, hasTeamRole, compareBotHierarchy } from '../../modules/moderation/service/exec.js';
 
 export default {
   name: 'warn',
@@ -25,23 +25,75 @@ export default {
       return;
     }
 
-    const lang = detectLangFromInteraction(interaction);
+    const lang = detectLangFromInteraction(interaction) ?? 'en';
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
     const embed = coreEmbed('ANN', lang);
 
-    if (!interaction.member?.roles?.cache?.has(TEAM_ROLE_ID)) {
+    if (!hasTeamRole(interaction.member)) {
       embed
         .setColor(ERROR_COLOR)
-        .setDescription(lang === 'de' ? 'Du benötigst die Team-Rolle.' : 'You need the team role.');
-      await interaction.reply({ ephemeral: true, embeds: [embed] });
+        .setDescription(lang === 'de' ? 'Keine Berechtigung (Team-Rolle erforderlich).' : 'Missing permission (team role required).');
+      await interaction.editReply({ embeds: [embed], components: [] });
       return;
     }
 
-    const target = interaction.options.getUser('target', true);
+    const targetUser = interaction.options.getUser('target', true);
+    if (!targetUser) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Ziel konnte nicht gelesen werden.' : 'Target user unavailable.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetUser.id === interaction.user.id) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Du kannst dich nicht selbst verwarnen.' : 'You cannot warn yourself.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetUser.bot) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Bots können nicht verwarnt werden.' : 'Bots cannot be warned.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    const targetMember = await interaction.guild.members.fetch(targetUser.id).catch(() => null);
+
+    if (hasTeamRole(targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Aktion blockiert: Ziel gehört zum Team.' : 'Action blocked: target is part of the team.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetMember && !compareHierarchy(interaction.member, targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Rollen-Hierarchie verhindert diese Aktion.' : 'Role hierarchy prevents this action.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
+    if (targetMember && !compareBotHierarchy(interaction.guild, targetMember)) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Bot-Rolle nicht hoch genug.' : 'Bot role hierarchy too low.');
+      await interaction.editReply({ embeds: [embed], components: [] });
+      return;
+    }
+
     const caseId = randomUUID();
     await createCase({
       id: caseId,
       guildId: interaction.guild.id,
-      userId: target.id,
+      userId: targetUser.id,
       moderatorId: interaction.user.id,
       actionType: ACTION.WARN,
     });
@@ -52,16 +104,15 @@ export default {
     embed
       .setDescription(
         lang === 'de'
-          ? `Bitte bestätige die Verwarnung für <@${target.id}> (Case #${caseId}).`
-          : `Configure the warning for <@${target.id}> (Case #${caseId}).`
+          ? `Bitte bestätige die Verwarnung für <@${targetUser.id}> (Case #${caseId}).`
+          : `Configure the warning for <@${targetUser.id}> (Case #${caseId}).`
       )
       .addFields({
         name: lang === 'de' ? 'Ziel' : 'Target',
-        value: `<@${target.id}> (${target.tag ?? target.id})`,
+        value: `<@${targetUser.id}> (${targetUser.tag ?? targetUser.id})`,
       });
 
-    await interaction.reply({
-      ephemeral: true,
+    await interaction.editReply({
       embeds: [embed],
       components: [reasonRow, confirmRow],
     });

--- a/src/modules/moderation/service/composeReason.js
+++ b/src/modules/moderation/service/composeReason.js
@@ -20,11 +20,19 @@ const REASON_TEMPLATES = {
 export function composeReasonText(codes = [], customReason = '', lang = 'en') {
   const language = lang === 'de' ? 'de' : 'en';
   const templates = REASON_TEMPLATES[language];
-  const uniqueCodes = Array.from(new Set(Array.isArray(codes) ? codes : [])).filter((code) =>
-    Object.prototype.hasOwnProperty.call(templates, code)
-  );
+  const labels = REASON_LABELS[language] ?? {};
 
-  const sentences = uniqueCodes.map((code) => templates[code]);
+  const uniqueCodes = Array.from(new Set(Array.isArray(codes) ? codes : []));
+  const sentences = [];
+
+  for (const code of uniqueCodes) {
+    if (templates[code]) {
+      sentences.push(templates[code]);
+    } else if (labels[code]) {
+      sentences.push(labels[code]);
+    }
+  }
+
   let text = '';
 
   if (sentences.length === 1) {
@@ -37,11 +45,12 @@ export function composeReasonText(codes = [], customReason = '', lang = 'en') {
 
   const custom = typeof customReason === 'string' ? customReason.trim() : '';
   if (custom) {
-    text = text ? `${text} ${custom}` : custom;
+    const suffix = custom.endsWith('.') ? custom : `${custom}.`;
+    text = text ? `${text} ${suffix}` : suffix;
   }
 
   if (!text) {
-    const fallback = REASON_LABELS[language]?.CUSTOM ?? 'Custom reason';
+    const fallback = labels.CUSTOM ?? 'Custom reason';
     return fallback;
   }
 

--- a/src/modules/tickets/interactions.js
+++ b/src/modules/tickets/interactions.js
@@ -18,6 +18,7 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
+  MessageFlags,
 } from 'discord.js';
 import { logger } from '../../util/logging/logger.js';
 
@@ -45,7 +46,7 @@ export async function handleTicketInteractions(interaction, client) {
           .setTitle('No Permission')
           .setDescription('You do not have permission to claim this ticket.')
           .setColor(0xff0000);
-        await interaction.reply({ embeds: [embed], ephemeral: true, allowedMentions: { parse: [] } });
+        await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral, allowedMentions: { parse: [] } });
         return;
       }
       await interaction.deferUpdate();
@@ -71,7 +72,7 @@ export async function handleTicketInteractions(interaction, client) {
       const embed = coreEmbed('TICKET', lang).setDescription(
         '🇺🇸 **Are you sure** you want to close this ticket?\n\n🇩🇪 **Bist du sicher**, dass du dieses Ticket schließen möchtest?'
       );
-      await interaction.reply({ embeds: [embed], components: [row], ephemeral: true, allowedMentions: { parse: [] } });
+      await interaction.reply({ embeds: [embed], components: [row], flags: MessageFlags.Ephemeral, allowedMentions: { parse: [] } });
       return;
     }
     case BTN_CLOSE_CONFIRM_ID: {
@@ -126,7 +127,7 @@ export async function handleTicketInteractions(interaction, client) {
       await interaction.reply({
         content: '🇺🇸 Reopen this ticket?\n🇩🇪 Dieses Ticket wieder eröffnen?',
         components: [row],
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
         allowedMentions: { parse: [] },
       });
       return;
@@ -192,7 +193,7 @@ export async function handleTicketInteractions(interaction, client) {
       await interaction.reply({
         embeds: [embed],
         components: [row],
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
         allowedMentions: { parse: [] },
       });
       return;

--- a/src/modules/tickets/open.js
+++ b/src/modules/tickets/open.js
@@ -12,6 +12,7 @@ import {
   ButtonBuilder,
   ButtonStyle,
   ChannelType,
+  MessageFlags,
   PermissionsBitField,
 } from 'discord.js';
 
@@ -19,7 +20,7 @@ export async function openTicket(interaction, lang = 'en') {
   const { guild, user } = interaction;
   const categoryId = TICKET_ACTIVE_CATEGORY_ID;
   if (!categoryId) {
-    await interaction.reply({ content: 'Fehler', ephemeral: true, allowedMentions: { parse: [] } });
+    await interaction.reply({ content: 'Fehler', flags: MessageFlags.Ephemeral, allowedMentions: { parse: [] } });
     return;
   }
 
@@ -71,7 +72,7 @@ export async function openTicket(interaction, lang = 'en') {
       permissionOverwrites: overwrites,
     });
   } catch {
-    await interaction.reply({ content: 'Fehler', ephemeral: true, allowedMentions: { parse: [] } });
+    await interaction.reply({ content: 'Fehler', flags: MessageFlags.Ephemeral, allowedMentions: { parse: [] } });
     return;
   }
 
@@ -83,7 +84,7 @@ export async function openTicket(interaction, lang = 'en') {
         ? `Ticket erstellt. Hier ist dein Ticket: ${ticketChannel}`
         : `Ticket created. Here is your ticket: ${ticketChannel}`
     );
-  await interaction.reply({ embeds: [replyEmbed], ephemeral: true, allowedMentions: { parse: [] } });
+  await interaction.reply({ embeds: [replyEmbed], flags: MessageFlags.Ephemeral, allowedMentions: { parse: [] } });
 
   const embed = coreEmbed('TICKET', lang).setDescription(
       lang === 'de'

--- a/src/modules/verify/interactions.js
+++ b/src/modules/verify/interactions.js
@@ -8,6 +8,7 @@ import {
   VERIFY_LANG_DE_ID,
   VERIFY_RESET_MS,
 } from './config.js';
+import { MessageFlags } from 'discord.js';
 import { buildVerifyEmbedAndComponents } from './embed.js';
 import { coreEmbed } from '../../util/embeds/core.js';
 import { detectLangFromInteraction } from '../../util/embeds/lang.js';
@@ -30,7 +31,7 @@ export async function handleVerifyInteractions(interaction, client) {
         .setTitle('Verification')
         .setDescription('⚠️ Verification failed. Please try again or contact staff.');
       try {
-        await interaction.reply({ embeds: [embed], ephemeral: true });
+        await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
       } catch (err) {
         verifyLogger.error('Antwort konnte nicht gesendet werden:', err);
       }
@@ -44,7 +45,7 @@ export async function handleVerifyInteractions(interaction, client) {
         .setTitle('Verification')
         .setDescription('ℹ️ You are already verified.');
       try {
-        await interaction.reply({ embeds: [embed], ephemeral: true });
+        await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
       } catch (err) {
         verifyLogger.error('Antwort konnte nicht gesendet werden:', err);
       }
@@ -57,7 +58,7 @@ export async function handleVerifyInteractions(interaction, client) {
         .setColor(0x00ff00)
         .setTitle('Verification')
         .setDescription('✅ You are now verified!');
-      await interaction.reply({ embeds: [embed], ephemeral: true });
+      await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
     } catch (err) {
       verifyLogger.warn('Rolle konnte nicht vergeben', err);
       const embed = coreEmbed('VERIFY', lang)
@@ -65,7 +66,7 @@ export async function handleVerifyInteractions(interaction, client) {
         .setTitle('Verification')
         .setDescription('⚠️ Verification failed. Please try again or contact staff.');
       try {
-        await interaction.reply({ embeds: [embed], ephemeral: true });
+        await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
       } catch (err) {
         verifyLogger.error('Antwort konnte nicht gesendet werden:', err);
       }


### PR DESCRIPTION
## Summary
- harden the interaction router and moderation UI handlers with early defers, MessageFlags usage, and Unknown Message guards
- enforce team role, permission, hierarchy, and bot/self checks across moderation slash commands before opening UI flows
- sanitize reason collection/composition and switch remaining feature modules to MessageFlags-based ephemeral responses

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1e4df3f1c832da0bd7eb64ae6b573