### PR TITLE
Fix moderation UI state persistence and component updates

### DIFF
--- a/src/modules/moderation/ui/customReasonModal.js
+++ b/src/modules/moderation/ui/customReasonModal.js
@@ -11,6 +11,10 @@ import { detectLangFromInteraction } from '../../../util/embeds/lang.js';
 import { CUSTOM_IDS, ERROR_COLOR, SUCCESS_COLOR, STATUS } from '../constants.js';
 import { setPendingCustomReason } from '../service/exec.js';
 import { getCaseById } from '../storage/repo.js';
+import { buildReasonsSelect } from './reasonsSelect.js';
+import { logger } from '../../../util/logging/logger.js';
+
+const uiLogger = logger.withPrefix('moderation:ui:custom-reason');
 
 const INPUT_ID = 'custom_reason_text';
 
@@ -44,53 +48,134 @@ export function isCustomReasonModal(interaction) {
   return interaction.isModalSubmit() && interaction.customId.startsWith(`${CUSTOM_IDS.REASON_MODAL}:`);
 }
 
-function safeEditReply(interaction, payload) {
-  return interaction.editReply(payload).catch((error) => {
+function replaceReasonRow(rows, newReasonRow) {
+  if (!rows?.length) {
+    return [newReasonRow];
+  }
+
+  let replaced = false;
+  const mapped = rows.map((row) => {
+    const isReasonRow = row.components?.some((component) =>
+      component.customId?.startsWith(`${CUSTOM_IDS.REASON_SELECT}:`)
+    );
+    if (isReasonRow) {
+      replaced = true;
+      return newReasonRow;
+    }
+    return ActionRowBuilder.from(row);
+  });
+
+  if (!replaced) {
+    mapped.push(newReasonRow);
+  }
+
+  return mapped;
+}
+
+async function editReplyWithFallback(interaction, payload) {
+  try {
+    await interaction.editReply(payload);
+  } catch (error) {
     if (error?.code === RESTJSONErrorCodes.UnknownMessage) {
-      return null;
+      const fallback = {
+        embeds: payload.embeds,
+        components: [],
+        flags: MessageFlags.Ephemeral,
+      };
+      if (interaction.deferred || interaction.replied) {
+        await interaction.followUp(fallback);
+      } else {
+        await interaction.reply(fallback);
+      }
+      return;
     }
     throw error;
-  });
+  }
 }
 
 export async function handleCustomReasonModal(interaction) {
   const lang = detectLangFromInteraction(interaction) ?? 'en';
-  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
   const caseId = parseCustomId(interaction.customId);
   const embed = coreEmbed('ANN', lang);
+  const errorMessage =
+    lang === 'de'
+      ? 'Etwas ist schiefgelaufen. Bitte versuche es erneut.'
+      : 'Something went wrong. Please try again.';
 
-  if (!caseId) {
-    embed.setColor(ERROR_COLOR).setDescription(lang === 'de' ? 'Fall-ID fehlt.' : 'Missing case id.');
-    await safeEditReply(interaction, { embeds: [embed] });
-    return;
-  }
+  try {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-  const caseRecord = await getCaseById(caseId);
-  if (!caseRecord || caseRecord.status !== STATUS.PENDING) {
-    embed.setColor(ERROR_COLOR).setDescription(
-      lang === 'de' ? 'Dieser Fall wurde bereits bearbeitet.' : 'This case has already been processed.'
+    if (!caseId) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Fall-ID fehlt.' : 'Missing case id.');
+      await editReplyWithFallback(interaction, { embeds: [embed] });
+      return;
+    }
+
+    const caseRecord = await getCaseById(caseId);
+    if (!caseRecord || caseRecord.status !== STATUS.PENDING) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(
+          lang === 'de'
+            ? 'Dieser Fall wurde bereits bearbeitet.'
+            : 'This case has already been processed.'
+        );
+      await editReplyWithFallback(interaction, { embeds: [embed] });
+      return;
+    }
+
+    const rawValue = interaction.fields.getTextInputValue(INPUT_ID);
+    const value = typeof rawValue === 'string' ? rawValue.trim() : '';
+    if (!value) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Bitte gib einen Grund ein.' : 'Please provide a reason.');
+      await editReplyWithFallback(interaction, { embeds: [embed] });
+      return;
+    }
+
+    const limited = value.slice(0, 300);
+    await setPendingCustomReason(caseId, limited, lang);
+
+    const updated = await getCaseById(caseId);
+    const newReasonRow = buildReasonsSelect(
+      caseId,
+      lang,
+      updated?.reasonCodes ?? caseRecord.reasonCodes ?? [],
+      Boolean(updated?.customReason)
     );
-    await safeEditReply(interaction, { embeds: [embed] });
-    return;
+    const baseComponents = interaction.message?.components ?? [];
+    const updatedComponents = baseComponents.length
+      ? replaceReasonRow(baseComponents, newReasonRow)
+      : baseComponents;
+
+    embed
+      .setColor(SUCCESS_COLOR)
+      .setDescription(lang === 'de' ? 'Eigener Grund gespeichert.' : 'Custom reason saved.');
+
+    await editReplyWithFallback(interaction, {
+      embeds: [embed],
+      components: updatedComponents,
+    });
+  } catch (error) {
+    uiLogger.error('Failed to handle custom reason modal', error);
+
+    if (!interaction.deferred && !interaction.replied) {
+      try {
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+      } catch (deferError) {
+        uiLogger.error('Failed to defer modal interaction', deferError);
+      }
+    }
+
+    const failureEmbed = coreEmbed('ANN', lang)
+      .setColor(ERROR_COLOR)
+      .setDescription(errorMessage);
+
+    await editReplyWithFallback(interaction, { embeds: [failureEmbed] });
   }
-
-  const rawValue = interaction.fields.getTextInputValue(INPUT_ID);
-  const value = typeof rawValue === 'string' ? rawValue.trim() : '';
-  if (!value) {
-    embed.setColor(ERROR_COLOR).setDescription(lang === 'de' ? 'Bitte gib einen Grund ein.' : 'Please provide a reason.');
-    await safeEditReply(interaction, { embeds: [embed] });
-    return;
-  }
-
-  const limited = value.slice(0, 300);
-  await setPendingCustomReason(caseId, limited, lang);
-
-  embed
-    .setColor(SUCCESS_COLOR)
-    .setDescription(lang === 'de' ? 'Eigener Grund gespeichert.' : 'Custom reason saved.');
-
-  await safeEditReply(interaction, { embeds: [embed] });
 }
 
 export { encodeCustomId as buildCustomReasonCustomId };

--- a/src/modules/moderation/ui/reasonsSelect.js
+++ b/src/modules/moderation/ui/reasonsSelect.js
@@ -12,6 +12,9 @@ import { CUSTOM_IDS, ERROR_COLOR, SUCCESS_COLOR, STATUS } from '../constants.js'
 import { getCaseById } from '../storage/repo.js';
 import { setPendingReasons, setPendingCustomReason } from '../service/exec.js';
 import { buildCustomReasonModal } from './customReasonModal.js';
+import { logger } from '../../../util/logging/logger.js';
+
+const uiLogger = logger.withPrefix('moderation:ui:reasons');
 
 function encodeCustomId(caseId) {
   return `${CUSTOM_IDS.REASON_SELECT}:${caseId}`;
@@ -22,8 +25,13 @@ function parseCustomId(customId) {
   return caseId;
 }
 
-export function buildReasonsSelect(caseId, lang = 'en') {
+export function buildReasonsSelect(caseId, lang = 'en', selectedCodes = [], includeCustom = false) {
   const language = lang === 'de' ? 'de' : 'en';
+  const selectedSet = new Set(selectedCodes ?? []);
+  if (includeCustom) {
+    selectedSet.add('CUSTOM');
+  }
+
   const select = new StringSelectMenuBuilder()
     .setCustomId(encodeCustomId(caseId))
     .setPlaceholder(language === 'de' ? 'Gründe auswählen' : 'Select reasons')
@@ -32,7 +40,11 @@ export function buildReasonsSelect(caseId, lang = 'en') {
 
   for (const code of REASON_CODES) {
     const label = REASON_LABELS[language][code] ?? code;
-    select.addOptions(new StringSelectMenuOptionBuilder().setLabel(label).setValue(code));
+    const option = new StringSelectMenuOptionBuilder()
+      .setLabel(label)
+      .setValue(code)
+      .setDefault(selectedSet.has(code));
+    select.addOptions(option);
   }
 
   return new ActionRowBuilder().addComponents(select);
@@ -42,112 +54,198 @@ export function isReasonsSelect(interaction) {
   return interaction.isStringSelectMenu() && interaction.customId.startsWith(`${CUSTOM_IDS.REASON_SELECT}:`);
 }
 
-function safeEditReply(interaction, payload) {
-  return interaction.editReply(payload).catch((error) => {
+function replaceReasonRow(rows, newReasonRow) {
+  if (!rows?.length) {
+    return [newReasonRow];
+  }
+
+  let replaced = false;
+  const mapped = rows.map((row) => {
+    const isReasonRow = row.components?.some((component) =>
+      component.customId?.startsWith(`${CUSTOM_IDS.REASON_SELECT}:`)
+    );
+    if (isReasonRow) {
+      replaced = true;
+      return newReasonRow;
+    }
+    return ActionRowBuilder.from(row);
+  });
+
+  if (!replaced) {
+    mapped.push(newReasonRow);
+  }
+
+  return mapped;
+}
+
+async function editReplyWithFallback(interaction, payload) {
+  try {
+    await interaction.editReply(payload);
+  } catch (error) {
     if (error?.code === RESTJSONErrorCodes.UnknownMessage) {
-      return null;
+      const fallback = {
+        embeds: payload.embeds,
+        components: [],
+        flags: MessageFlags.Ephemeral,
+      };
+      if (interaction.deferred || interaction.replied) {
+        await interaction.followUp(fallback);
+      } else {
+        await interaction.reply(fallback);
+      }
+      return;
     }
     throw error;
-  });
+  }
 }
 
 export async function handleReasonsSelect(interaction) {
   const lang = detectLangFromInteraction(interaction) ?? 'en';
   const caseId = parseCustomId(interaction.customId);
   const embed = coreEmbed('ANN', lang);
+  const errorMessage =
+    lang === 'de'
+      ? 'Etwas ist schiefgelaufen. Bitte versuche es erneut.'
+      : 'Something went wrong. Please try again.';
 
-  if (!caseId) {
-    embed.setColor(ERROR_COLOR).setDescription(
-      lang === 'de' ? 'Der Fall fehlt.' : 'Missing case identifier.'
-    );
-    await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
-    await safeEditReply(interaction, {
-      embeds: [embed],
-      components: interaction.message?.components ?? [],
-    });
-    return;
-  }
+  try {
+    if (!caseId) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Der Fall fehlt.' : 'Missing case identifier.');
+      await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
+      await editReplyWithFallback(interaction, {
+        embeds: [embed],
+        components: interaction.message?.components ?? [],
+      });
+      return;
+    }
 
-  const caseRecord = await getCaseById(caseId);
-  if (!caseRecord) {
-    embed.setColor(ERROR_COLOR).setDescription(lang === 'de' ? 'Fall nicht gefunden.' : 'Case not found.');
-    await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
-    await safeEditReply(interaction, {
-      embeds: [embed],
-      components: interaction.message?.components ?? [],
-    });
-    return;
-  }
+    const caseRecord = await getCaseById(caseId);
+    if (!caseRecord) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(lang === 'de' ? 'Fall nicht gefunden.' : 'Case not found.');
+      await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
+      await editReplyWithFallback(interaction, {
+        embeds: [embed],
+        components: interaction.message?.components ?? [],
+      });
+      return;
+    }
 
-  if (caseRecord.status !== STATUS.PENDING) {
-    embed.setColor(ERROR_COLOR).setDescription(
-      lang === 'de' ? 'Dieser Fall wurde bereits bearbeitet.' : 'This case has already been processed.'
-    );
-    await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
-    await safeEditReply(interaction, {
-      embeds: [embed],
-      components: interaction.message?.components ?? [],
-    });
-    return;
-  }
+    if (caseRecord.status !== STATUS.PENDING) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(
+          lang === 'de'
+            ? 'Dieser Fall wurde bereits bearbeitet.'
+            : 'This case has already been processed.'
+        );
+      await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
+      await editReplyWithFallback(interaction, {
+        embeds: [embed],
+        components: interaction.message?.components ?? [],
+      });
+      return;
+    }
 
-  const rawValues = interaction.values ?? [];
-  const uniqueValues = Array.from(new Set(rawValues));
+    const rawValues = interaction.values ?? [];
+    const uniqueValues = Array.from(new Set(rawValues));
 
-  if (!uniqueValues.length) {
-    embed.setColor(ERROR_COLOR).setDescription(
-      lang === 'de' ? 'Bitte wähle mindestens einen Grund.' : 'Please select at least one reason.'
-    );
-    await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
-    await safeEditReply(interaction, {
-      embeds: [embed],
-      components: interaction.message?.components ?? [],
-    });
-    return;
-  }
+    if (!uniqueValues.length) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(
+          lang === 'de' ? 'Bitte wähle mindestens einen Grund.' : 'Please select at least one reason.'
+        );
+      await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
+      await editReplyWithFallback(interaction, {
+        embeds: [embed],
+        components: interaction.message?.components ?? [],
+      });
+      return;
+    }
 
-  if (uniqueValues.length > 5) {
-    embed.setColor(ERROR_COLOR).setDescription(
-      lang === 'de' ? 'Maximal 5 Gründe möglich.' : 'You can choose at most 5 reasons.'
-    );
-    await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
-    await safeEditReply(interaction, {
-      embeds: [embed],
-      components: interaction.message?.components ?? [],
-    });
-    return;
-  }
+    if (uniqueValues.length > 5) {
+      embed
+        .setColor(ERROR_COLOR)
+        .setDescription(
+          lang === 'de' ? 'Maximal 5 Gründe möglich.' : 'You can choose at most 5 reasons.'
+        );
+      await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
+      await editReplyWithFallback(interaction, {
+        embeds: [embed],
+        components: interaction.message?.components ?? [],
+      });
+      return;
+    }
 
-  const needsCustom = uniqueValues.includes('CUSTOM');
-  const filtered = uniqueValues.filter((code) => code !== 'CUSTOM');
+    const needsCustom = uniqueValues.includes('CUSTOM');
+    const filtered = uniqueValues.filter((code) => code !== 'CUSTOM');
 
-  if (needsCustom) {
     await setPendingReasons(caseId, filtered, lang);
     await setPendingCustomReason(caseId, null, lang);
-    const modal = buildCustomReasonModal(caseId, lang);
-    await interaction.showModal(modal);
-    return;
-  }
 
-  await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
-
-  await setPendingReasons(caseId, filtered, lang);
-  await setPendingCustomReason(caseId, null, lang);
-
-  const language = lang === 'de' ? 'de' : 'en';
-  const labelMap = REASON_LABELS[language] ?? {};
-  embed
-    .setColor(SUCCESS_COLOR)
-    .setDescription(
-      language === 'de'
-        ? `Gründe gespeichert: ${filtered.map((code) => labelMap[code] ?? code).join(', ')}`
-        : `Reasons saved: ${filtered.map((code) => labelMap[code] ?? code).join(', ')}`
+    const updated = await getCaseById(caseId);
+    const newReasonRow = buildReasonsSelect(
+      caseId,
+      lang,
+      updated?.reasonCodes ?? filtered,
+      Boolean(updated?.customReason)
     );
+    const updatedComponents = replaceReasonRow(interaction.message?.components ?? [], newReasonRow);
 
-  await safeEditReply(interaction, {
-    embeds: [embed],
-    components: interaction.message?.components ?? [],
-  });
+    if (needsCustom) {
+      const modal = buildCustomReasonModal(caseId, lang);
+      await interaction.showModal(modal);
+
+      const currentEmbeds = interaction.message?.embeds?.length
+        ? interaction.message.embeds
+        : [embed];
+      await editReplyWithFallback(interaction, {
+        embeds: currentEmbeds,
+        components: updatedComponents,
+      });
+      return;
+    }
+
+    await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
+
+    const language = lang === 'de' ? 'de' : 'en';
+    const labelMap = REASON_LABELS[language] ?? {};
+    embed
+      .setColor(SUCCESS_COLOR)
+      .setDescription(
+        language === 'de'
+          ? `Gründe gespeichert: ${filtered.map((code) => labelMap[code] ?? code).join(', ')}`
+          : `Reasons saved: ${filtered.map((code) => labelMap[code] ?? code).join(', ')}`
+      );
+
+    await editReplyWithFallback(interaction, {
+      embeds: [embed],
+      components: updatedComponents,
+    });
+  } catch (error) {
+    uiLogger.error('Failed to handle reasons select', error);
+
+    if (!interaction.deferred && !interaction.replied) {
+      try {
+        await interaction.deferUpdate({ flags: MessageFlags.Ephemeral });
+      } catch (deferError) {
+        uiLogger.error('Failed to defer interaction for reasons select', deferError);
+      }
+    }
+
+    const failureEmbed = coreEmbed('ANN', lang)
+      .setColor(ERROR_COLOR)
+      .setDescription(errorMessage);
+
+    await editReplyWithFallback(interaction, {
+      embeds: [failureEmbed],
+      components: interaction.message?.components ?? [],
+    });
+  }
 }
 
 export { encodeCustomId as buildReasonCustomId };


### PR DESCRIPTION
## Summary
- refresh moderation reason selection UI using persisted case data and resilient message edits
- update custom reason modal and duration selector to rebuild component defaults after saving
- ensure confirm actions disable all components once and add consistent error handling and logging

## Testing
- npm test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ed64d570832dabe8477101b94cdf